### PR TITLE
Implement groups command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Baloo 🐻 
-![Progress](https://img.shields.io/badge/progress-57%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-58%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 <center><img src="assets/Baloo.jpg" title=" भालू "></img></center>
@@ -67,7 +67,7 @@ for whichever `.asm` in `src` you want to compile.
 - [`getopts`](src/getopts.asm) Parse utility options
 - [`gettext`](src/gettext.asm) Retrieve text string from messages object
 - [`grep`](src/grep.asm) Search text for a pattern
-- [`groups`](src/groups.asm) Prints the groups of which the user is a member
+- [`groups`](src/groups.asm) ✅ Prints the groups of which the user is a member
 - [`hash`](src/hash.asm) Hash database access method
 - [`head`](src/head.asm) ✅ Output the beginning of files
 - [`hostid`](src/hostid.asm) ✅ Prints the numeric identifier for the current host

--- a/src/groups.asm
+++ b/src/groups.asm
@@ -1,0 +1,66 @@
+; src/groups.asm
+
+%include "include/sysdefs.inc"
+
+section .bss
+    groups_buf  resd 32         ; buffer for group IDs (32-bit each)
+    numbuf      resb 16         ; temporary buffer for printing numbers
+
+section .data
+    newline     db 10
+    space       db ' '
+
+section .text
+    global _start
+
+_start:
+    mov     rax, SYS_GETGROUPS
+    mov     rdi, 32             ; max groups
+    mov     rsi, groups_buf
+    syscall
+
+    mov     rcx, rax            ; number of groups
+    cmp     rcx, 0
+    je      .done
+
+    xor     rbx, rbx            ; index
+.next_group:
+    mov     edi, [groups_buf + rbx*4]
+    call    print_num
+
+    inc     rbx
+    cmp     rbx, rcx
+    je      .done
+
+    call    write_space
+    jmp     .next_group
+
+.done:
+    write   STDOUT_FILENO, newline, 1
+    exit    0
+
+print_num:
+    mov     rax, rdi
+    mov     rsi, numbuf + 15
+    mov     byte [rsi], 0
+    mov     rcx, 10
+
+.print_loop:
+    xor     rdx, rdx
+    div     rcx
+    dec     rsi
+    add     dl, '0'
+    mov     [rsi], dl
+    test    rax, rax
+    jnz     .print_loop
+
+    mov     rax, SYS_WRITE
+    mov     rdi, STDOUT_FILENO
+    mov     rdx, numbuf + 16
+    sub     rdx, rsi
+    syscall
+    ret
+
+write_space:
+    write   STDOUT_FILENO, space, 1
+    ret

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -116,6 +116,11 @@ teardown(){ rm -rf "$TMP"; }
   [ "$(echo "$output" | head -1 | wc -c)" -le 21 ]    # 20 chars + newline
 }
 
+@test "groups — prints numeric groups" {
+  run "$BIN/groups"
+  assert_output "$(id -G)"
+}
+
 @test "head — first line only" {
   printf '1\n2\n3\n' >"$TMP/l"
   run "$BIN/head" -n 1 "$TMP/l"


### PR DESCRIPTION
## Summary
- add a simple `groups` utility printing numeric group IDs
- mark `groups` as complete in the catalog and update progress count
- test the new command

## Testing
- `make`
- `bats tests/test_all.bats` *(fails: bats-support not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3b6581e0832891b0124a660234e2