### PR TITLE
Add benchmarking and fix echo segfault

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,6 @@ for whichever `.asm` in `src` you want to compile.
 - [`write`](src/write.asm) Write to another user's terminal
 - [`xargs`](src/xargs.asm) Construct argument lists and invoke utility
 - [`yes`](src/yes.asm) ✅ Prints a string repeatedly
+
+## Benchmark
+Run `make` to build all binaries, then execute `./benchmark.sh` to compare a few Baloo programs against the system implementations using `hyperfine`.

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Benchmark Baloo's assembly utilities against system utilities.
+
+set -e
+
+BALOOBIN="$(dirname "$0")/bin"
+
+# Ensure hyperfine is installed
+if ! command -v hyperfine >/dev/null; then
+  echo "hyperfine not found. Install it with: sudo apt-get install -y hyperfine" >&2
+  exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Prepare a 1MB test file for commands that need input
+head -c 1048576 </dev/urandom > "$TMPDIR/file"
+
+benchmark() {
+  local name=$1
+  shift
+  echo "\n== $name =="
+  hyperfine --ignore-failure "$@"
+}
+
+benchmark "cat"    "$BALOOBIN/cat $TMPDIR/file > /dev/null"    "cat $TMPDIR/file > /dev/null"
+benchmark "echo"   "$BALOOBIN/echo hello > /dev/null"         "echo hello > /dev/null"
+benchmark "true"   "$BALOOBIN/true"                             "/bin/true"
+benchmark "false"  "$BALOOBIN/false"                            "/bin/false"
+benchmark "base64" "$BALOOBIN/base64 $TMPDIR/file > /dev/null" "base64 $TMPDIR/file > /dev/null"

--- a/include/sysdefs.inc
+++ b/include/sysdefs.inc
@@ -18,6 +18,8 @@ section .data
     error_msg_write db "Error writing file", 10
     error_msg_write_len equ $ - error_msg_write
 
+section .text
+
 open_file:
     cmp rsi, 0
     je .use_default


### PR DESCRIPTION
## Summary
- fix section placement so helper functions go in `.text`
- add `benchmark.sh` to compare Baloo binaries with system ones
- document benchmarking in README

## Testing
- `./benchmark.sh > /tmp/bench.log`


------
https://chatgpt.com/codex/tasks/task_e_683f3bab5af88328a3105d3df581ed65