### PR TITLE
Add bats tests to CI

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -17,3 +17,11 @@ jobs:
       run: make clean
     - name: Compile
       run: make
+    - name: Install test dependencies
+      run: |
+        sudo apt-get install -y bats bats-assert bats-support
+        mkdir -p tests/test_helper
+        ln -s /usr/lib/bats/bats-support tests/test_helper/bats-support
+        ln -s /usr/lib/bats/bats-assert tests/test_helper/bats-assert
+    - name: Test
+      run: make test


### PR DESCRIPTION
## Summary
- add installation of bats toolchain and run `make test` in CI workflow

## Testing
- `make clean && make`
- `make test` *(fails: bats suite reports failures)*

------
https://chatgpt.com/codex/tasks/task_e_6841ff264aa8832892b6087f7fe5f662