### PR TITLE
Implement `command` utility

### DIFF
--- a/Baloo.json
+++ b/Baloo.json
@@ -135,7 +135,7 @@
     "name": "command",
     "description": "Executes a simple command",
     "glyph": "⚡",
-    "isDone": false
+    "isDone": true
   },
   {
     "name": "cp",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baloo 🐻 
 
-![Progress](https://img.shields.io/badge/progress-58%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-59%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 <center><img src="assets/Baloo.jpg" title=" भालू "></img></center>
@@ -49,7 +49,7 @@ python3 scripts/asmfmt.py src/example.asm
 - [`cksum`](src/cksum.asm) Checksums (IEEE Ethernet CRC-32) and count the bytes in a file
 - [`cmp`](src/cmp.asm) ✅ Compares two files; see also diff
 - [`comm`](src/comm.asm) Compares two sorted files line by line
-- [`command`](src/command.asm) Executes a simple command
+- [`command`](src/command.asm) ✅ Executes a simple command
 - [`cp`](src/cp.asm) ✅ Copy files/directories
 - [`crontab`](src/crontab.asm) Schedule periodic background work
 - [`csplit`](src/csplit.asm) Splits a file into sections determined by context lines

--- a/src/command.asm
+++ b/src/command.asm
@@ -1,0 +1,31 @@
+; src/command.asm
+
+    %include "include/sysdefs.inc"
+
+section .bss
+
+section .data
+execve_fail_msg db "Error: execve failed", 10
+    execve_fail_len equ $ - execve_fail_msg
+
+section .text
+global _start
+
+_start:
+    pop     rdi                         ;argc
+    mov     rbx, rsp                    ;argv pointer
+    lea     rdx, [rbx + rdi*8 + 8]      ;envp pointer
+    cmp     rdi, 1
+    jle     .exit_success
+
+    add     rbx, 8                      ;skip program name
+    mov     rsi, rbx                    ;argv for execve
+    mov     rdi, [rsi]                  ;command path
+    mov     rax, SYS_EXECVE
+    syscall
+
+    write   STDERR_FILENO, execve_fail_msg, execve_fail_len
+    exit    1
+
+.exit_success:
+    exit    0


### PR DESCRIPTION
## Summary
- add new `command` assembly source
- mark `command` as implemented in README and Baloo.json

## Testing
- `make test` *(fails: `bats` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846310012d08328982ee31aec3d5b7a