### PR TITLE
Add dircolors utility

### DIFF
--- a/Baloo.json
+++ b/Baloo.json
@@ -189,7 +189,7 @@
     "name": "dircolors",
     "description": "Set up color for ls",
     "glyph": "🎨",
-    "isDone": false
+    "isDone": true
   },
   {
     "name": "dirname",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baloo 🐻 
 
-![Progress](https://img.shields.io/badge/progress-58%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-59%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 <center><img src="assets/Baloo.jpg" title=" भालू "></img></center>
@@ -58,7 +58,7 @@ python3 scripts/asmfmt.py src/example.asm
 - [`dd`](src/dd.asm) Copies and converts a file
 - [`df`](src/df.asm) Shows disk free space on file systems
 - [`diff`](src/diff.asm) Compare two files; see also cmp
-- [`dircolors`](src/dircolors.asm) Set up color for ls
+- [`dircolors`](src/dircolors.asm) ✅ Set up color for ls
 - [`dirname`](src/dirname.asm) ✅ Strips non-directory suffix from file name
 - [`du`](src/du.asm) Shows disk usage on file systems
 - [`echo`](src/echo.asm) ✅ Displays a specified line of text

--- a/src/dircolors.asm
+++ b/src/dircolors.asm
@@ -1,0 +1,15 @@
+; src/dircolors.asm
+
+    %include "include/sysdefs.inc"
+
+section .data
+msg db "LS_COLORS='di=01;34:ln=01;36:so=01;35:pi=33:bd=01;33:cd=01;33:or=01;31:ex=01;32'", 10, "export LS_COLORS", 10
+    msg_len equ $ - msg
+
+section .text
+global _start
+
+_start:
+    write STDOUT_FILENO, msg, msg_len
+    exit 0
+


### PR DESCRIPTION
## Summary
- implement a basic `dircolors` utility
- mark `dircolors` as done in README and Baloo.json
- update progress badge in README

## Testing
- `make all`
- `make test` *(fails: `bats` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846312a40ac832880106d17f2f5d694