### PR TITLE
Add gettext assembly command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ python3 scripts/asmfmt.py src/example.asm
 - [`gencat`](src/gencat.asm) Generate a formatted message catalog
 - [`getconf`](src/getconf.asm) Get configuration values
 - [`getopts`](src/getopts.asm) Parse utility options
-- [`gettext`](src/gettext.asm) Retrieve text string from messages object
+- [`gettext`](src/gettext.asm) ✅ Retrieve text string from messages object
 - [`grep`](src/grep.asm) Search text for a pattern
 - [`groups`](src/groups.asm) ✅ Prints the groups of which the user is a member
 - [`hash`](src/hash.asm) Hash database access method

--- a/src/gettext.asm
+++ b/src/gettext.asm
@@ -1,0 +1,29 @@
+; src/gettext.asm
+
+%include "include/sysdefs.inc"
+
+section .bss
+
+section .data
+    newline     db WHITESPACE_NL
+
+section .text
+    global _start
+
+_start:
+    mov     rsi, rsp
+    mov     rdi, [rsi]        ; argc
+    add     rsi, 8            ; argv[0]
+    add     rsi, 8            ; argv[1]
+    cmp     rdi, 1
+    jle     .print_nl
+
+    mov     rsi, [rsi]
+    call    strlen
+
+    write   STDOUT_FILENO, rsi, rbx
+
+.print_nl:
+    write   STDOUT_FILENO, newline, 1
+    exit    0
+


### PR DESCRIPTION
## Summary
- implement a basic `gettext` command that prints its argument
- mark `gettext` as done in the README

## Testing
- `make test` *(fails: bats support files missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846316a8fe483289de3089764527df5