### PR TITLE
Add mknod utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baloo 🐻 
 
-![Progress](https://img.shields.io/badge/progress-58%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-59%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 <center><img src="assets/Baloo.jpg" title=" भालू "></img></center>
@@ -101,7 +101,7 @@ python3 scripts/asmfmt.py src/example.asm
 - [`mesg`](src/mesg.asm) ✅ Permit or deny messages
 - [`mkdir`](src/mkdir.asm) ✅ Creates directories
 - [`mkfifo`](src/mkfifo.asm) ✅ Makes named pipes (FIFOs)
-- [`mknod`](src/mknod.asm) Makes block or character special files
+- [`mknod`](src/mknod.asm) ✅ Makes block or character special files
 - [`mktemp`](src/mktemp.asm) ✅ Creates a temporary file or directory
 - [`msgfmt`](src/msgfmt.asm) Create messages objects from messages object files
 - [`mv`](src/mv.asm) ✅ Moves files or rename files

--- a/include/defines.inc
+++ b/include/defines.inc
@@ -81,6 +81,8 @@
 %define O_APPEND        1024    ; Open for appending
 
 %define S_IFIFO       0o010000  ; FIFO file type
+%define S_IFCHR       0o020000  ; Character device file type
+%define S_IFBLK       0o060000  ; Block device file type
 %define S_IRUSR       0o0400    ; Read permission for owner
 %define S_IWUSR       0o0200    ; Write permission for owner
 %define S_IRGRP       0o0040    ; Read permission for group

--- a/src/mknod.asm
+++ b/src/mknod.asm
@@ -1,0 +1,112 @@
+; src/mknod.asm
+
+    %include "include/sysdefs.inc"
+
+    %define S_IFCHR 0o020000
+    %define S_IFBLK 0o060000
+
+section .bss
+
+section .data
+usage_msg db "Usage: mknod NAME TYPE [MAJOR MINOR]", 10
+    usage_len equ $ - usage_msg
+error_msg db "Error: mknod failed", 10
+    error_len equ $ - error_msg
+
+section .text
+global _start
+
+_start:
+    pop rcx                             ;argc
+    cmp rcx, 3                          ;need at least name and type
+    jb usage
+    cmp rcx, 5                          ;at most name type major minor
+    ja usage
+
+    add rsp, 8                          ;skip program name
+    pop r12                             ;name pointer
+    pop rbx                             ;type pointer
+    mov bl, [rbx]
+
+    cmp bl, 'p'
+    je create_fifo
+    cmp bl, 'c'
+    je create_charblock
+    cmp bl, 'b'
+    je create_charblock
+    jmp usage
+
+create_fifo:
+    cmp rcx, 3
+    jne usage
+    mov rax, SYS_MKNOD
+    mov rdi, r12
+    mov rsi, S_IFIFO | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
+    xor rdx, rdx
+    syscall
+    test rax, rax
+    js fail
+    exit 0
+
+create_charblock:
+    cmp rcx, 5
+    jne usage
+    pop rdi                             ;major string
+    call parse_number
+    cmp rax, -1
+    je usage
+    mov r8, rax
+    pop rdi                             ;minor string
+    call parse_number
+    cmp rax, -1
+    je usage
+    mov r9, rax
+
+    mov rax, r8
+    shl rax, 8
+    or  rax, r9
+    mov rdx, rax
+    mov rdi, r12
+    mov rax, SYS_MKNOD
+    cmp bl, 'b'
+    je .block
+    mov rsi, S_IFCHR | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
+    jmp .call
+.block:
+    mov rsi, S_IFBLK | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
+.call:
+    syscall
+    test rax, rax
+    js fail
+    exit 0
+
+usage:
+    write STDERR_FILENO, usage_msg, usage_len
+    exit 1
+
+fail:
+    write STDERR_FILENO, error_msg, error_len
+    exit 1
+
+parse_number:
+    xor rax, rax
+    xor rcx, rcx
+.loop:
+    movzx rdx, byte [rdi+rcx]
+    test rdx, rdx
+    jz .done
+    sub rdx, '0'
+    cmp rdx, 9
+    ja .error
+    imul rax, 10
+    add rax, rdx
+    inc rcx
+    jmp .loop
+.done:
+    test rcx, rcx
+    jz .error
+    ret
+.error:
+    mov rax, -1
+    ret
+

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -185,6 +185,12 @@ teardown(){ rm -rf "$TMP"; }
   assert [ -p "$TMP/p" ]
 }
 
+@test "mknod — creates fifo" {
+  run "$BIN/mknod" "$TMP/nod" p
+  assert_success
+  assert [ -p "$TMP/nod" ]
+}
+
 @test "mktemp — returns unique path" {
   run "$BIN/mktemp" -u
   assert_success


### PR DESCRIPTION
## Summary
- implement `mknod` for creating FIFOs and device nodes
- expose `S_IFCHR` and `S_IFBLK` constants
- mark `mknod` as complete in README
- test `mknod` via bats

## Testing
- `make`
- `make test` *(fails: bats missing)*

------
https://chatgpt.com/codex/tasks/task_e_684631c63090832890008adc517d7572