### PR TITLE
Implement md5sum using kernel crypto

### DIFF
--- a/Baloo.json
+++ b/Baloo.json
@@ -423,7 +423,7 @@
     "name": "md5sum",
     "description": "Computes and checks MD5 message digest",
     "glyph": "🔑",
-    "isDone": false
+    "isDone": true
   },
   {
     "name": "mesg",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baloo 🐻 
 
-![Progress](https://img.shields.io/badge/progress-58%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-59%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 <center><img src="assets/Baloo.jpg" title=" भालू "></img></center>

--- a/include/defines.inc
+++ b/include/defines.inc
@@ -14,6 +14,10 @@
 
 %define SYS_GETPID      39
 
+%define SYS_SOCKET      41
+%define SYS_ACCEPT      43
+%define SYS_BIND        49
+
 %define SYS_EXECVE      59
 
 %define SYS_EXIT        60
@@ -128,3 +132,6 @@
 %define WHITESPACE_TAB  9       ; '\t'
 %define WHITESPACE_NL   10      ; '\n'
 %define WHITESPACE_SPACE 32     ; ' '
+
+%define AF_ALG          38
+%define SOCK_SEQPACKET  5

--- a/src/md5sum.asm
+++ b/src/md5sum.asm
@@ -1,0 +1,134 @@
+; src/md5sum.asm
+
+%include "include/sysdefs.inc"
+
+%define BUFFER_SIZE 4096
+
+section .bss
+    buffer      resb BUFFER_SIZE        ; read buffer
+    digest      resb 16                 ; MD5 result
+    hex_output  resb 32                 ; hex string
+    newline     resb 1
+
+section .data
+    hex_chars   db "0123456789abcdef"
+
+    sockaddr:
+        dw AF_ALG                      ; salg_family
+        db 'hash',0,0,0,0,0,0,0,0,0,0   ; salg_type[14]
+        dd 0                           ; salg_feat
+        dd 0                           ; salg_mask
+        db 'md5',0
+        times (64-4) db 0
+    sockaddr_len equ $ - sockaddr
+
+section .text
+    global _start
+
+_start:
+    pop rcx                     ; argc
+    pop rbx                     ; argv[0]
+    dec rcx
+    jz  .use_stdin
+
+    pop rsi                     ; filename
+    mov rdi, STDIN_FILENO
+    call open_file
+    mov r14, rax                ; input fd
+    jmp .setup_socket
+
+.use_stdin:
+    mov r14, STDIN_FILENO
+
+.setup_socket:
+    mov rax, SYS_SOCKET
+    mov rdi, AF_ALG
+    mov rsi, SOCK_SEQPACKET
+    xor rdx, rdx
+    syscall
+    cmp rax, 0
+    jl  .error
+    mov r15, rax
+
+    mov rdi, r15
+    lea rsi, [rel sockaddr]
+    mov rdx, sockaddr_len
+    mov rax, SYS_BIND
+    syscall
+    cmp rax, 0
+    jl  .error
+
+    mov rdi, r15
+    xor rsi, rsi
+    xor rdx, rdx
+    mov rax, SYS_ACCEPT
+    syscall
+    cmp rax, 0
+    jl  .error
+    mov r13, rax                ; op fd
+
+.read_loop:
+    mov rax, SYS_READ
+    mov rdi, r14
+    mov rsi, buffer
+    mov rdx, BUFFER_SIZE
+    syscall
+    cmp rax, 0
+    jl  .error
+    je  .finish
+    mov rcx, rax
+    mov rax, SYS_WRITE
+    mov rdi, r13
+    mov rsi, buffer
+    mov rdx, rcx
+    syscall
+    cmp rax, 0
+    jl  .error
+    jmp .read_loop
+
+.finish:
+    mov rax, SYS_READ
+    mov rdi, r13
+    lea rsi, [digest]
+    mov rdx, 16
+    syscall
+    cmp rax, 0
+    jl  .error
+
+    cmp r14, STDIN_FILENO
+    je  .skip_close
+    mov rax, SYS_CLOSE
+    mov rdi, r14
+    syscall
+.skip_close:
+    mov rax, SYS_CLOSE
+    mov rdi, r13
+    syscall
+    mov rax, SYS_CLOSE
+    mov rdi, r15
+    syscall
+
+    ; convert digest to hex
+    lea rdi, [digest]
+    lea rsi, [hex_output]
+    mov rcx, 16
+.hex_loop:
+    movzx rax, byte [rdi]
+    mov rdx, rax
+    shr rdx, 4
+    mov bl, [hex_chars + rdx]
+    mov [rsi], bl
+    and al, 0xF
+    mov bl, [hex_chars + rax]
+    mov [rsi + 1], bl
+    inc rdi
+    add rsi, 2
+    loop .hex_loop
+
+    mov byte [newline], 10
+    write STDOUT_FILENO, hex_output, 32
+    write STDOUT_FILENO, newline, 1
+    exit 0
+
+.error:
+    exit 1

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -173,6 +173,12 @@ teardown(){ rm -rf "$TMP"; }
   assert_output --partial "zzz"
 }
 
+@test "md5sum — digests stdin" {
+  printf 'hi' | run "$BIN/md5sum"
+  assert_success
+  assert_output '49f68a5c8493ec2c0bf489821c21fc3b'
+}
+
 @test "mkdir — creates directory" {
   run "$BIN/mkdir" "$TMP/dir"
   assert_success


### PR DESCRIPTION
## Summary
- implement `md5sum` using Linux AF_ALG sockets
- expose needed syscall and socket constants
- mark `md5sum` complete in catalog and README progress
- test `md5sum` via new Bats check

## Testing
- `make`
- `make test` *(fails: bats-support not found)*

------
https://chatgpt.com/codex/tasks/task_e_684631bc6364832889c64d108227ea90