### PR TITLE
Implement install utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baloo 🐻 
 
-![Progress](https://img.shields.io/badge/progress-58%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-59%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 <center><img src="assets/Baloo.jpg" title=" भालू "></img></center>
@@ -83,7 +83,7 @@ python3 scripts/asmfmt.py src/example.asm
 - [`hostid`](src/hostid.asm) ✅ Prints the numeric identifier for the current host
 - [`iconv`](src/iconv.asm) Codeset conversion
 - [`id`](src/id.asm) ✅ Prints real or effective UID and GID
-- [`install`](src/install.asm) Copies files and set attributes
+- [`install`](src/install.asm) ✅ Copies files and set attributes
 - [`join`](src/join.asm) Merges two sorted text files based on the presence of a common field
 - [`kill`](src/kill.asm) ✅ Terminate or signal processes
 - [`link`](src/link.asm) ✅ Creates a link to a file

--- a/src/install.asm
+++ b/src/install.asm
@@ -1,0 +1,89 @@
+; src/install.asm
+
+%include "include/sysdefs.inc"
+
+%define BUFFER_SIZE 4096
+
+section .bss
+    buffer      resb BUFFER_SIZE
+    dest_ptr    resq 1
+
+section .data
+    usage_msg       db "Usage: install SOURCE DEST", 10
+    usage_len       equ $ - usage_msg
+    chmod_err_msg   db "install: failed to set permissions", 10
+    chmod_err_len   equ $ - chmod_err_msg
+
+section .text
+    global _start
+
+_start:
+    pop     rcx                 ; argc
+    cmp     rcx, 3
+    jne     usage_error
+
+    pop     rdi                 ; skip program name
+
+    pop     rsi                 ; source path
+    mov     rdi, STDIN_FILENO
+    call    open_file
+    mov     r8, rax             ; source fd
+
+    pop     rsi                 ; destination path
+    mov     [dest_ptr], rsi     ; save for chmod
+    mov     rdi, STDOUT_FILENO
+    call    open_dest_file
+    mov     r9, rax             ; dest fd
+
+copy_loop:
+    mov     rax, SYS_READ
+    mov     rdi, r8
+    mov     rsi, buffer
+    mov     rdx, BUFFER_SIZE
+    syscall
+
+    cmp     rax, 0
+    jl      read_error
+    je      copy_done
+
+    mov     rdx, rax
+    mov     rax, SYS_WRITE
+    mov     rdi, r9
+    mov     rsi, buffer
+    syscall
+    cmp     rax, 0
+    jl      write_error
+    jmp     copy_loop
+
+copy_done:
+    mov     rax, SYS_CLOSE
+    mov     rdi, r8
+    syscall
+    mov     rax, SYS_CLOSE
+    mov     rdi, r9
+    syscall
+
+    mov     rax, SYS_CHMOD
+    mov     rdi, [dest_ptr]
+    mov     rsi, 0o755
+    syscall
+    test    rax, rax
+    js      chmod_error
+
+    exit    0
+
+usage_error:
+    write   STDERR_FILENO, usage_msg, usage_len
+    exit    1
+
+read_error:
+    write   STDERR_FILENO, error_msg_read, error_msg_read_len
+    exit    1
+
+write_error:
+    write   STDERR_FILENO, error_msg_write, error_msg_write_len
+    exit    1
+
+chmod_error:
+    write   STDERR_FILENO, chmod_err_msg, chmod_err_len
+    exit    1


### PR DESCRIPTION
## Summary
- add initial implementation of `install` for copying files and setting permissions
- mark `install` as complete in README and update progress badge

## Testing
- `make test` *(fails: bats not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68463182a5dc8328a587168f2bd299b5