### PR TITLE
Add stub iconv utility

### DIFF
--- a/src/iconv.asm
+++ b/src/iconv.asm
@@ -1,0 +1,14 @@
+; src/iconv.asm
+
+%include "include/sysdefs.inc"
+
+section .data
+    msg db "iconv: not implemented", WHITESPACE_NL
+    msg_len equ $ - msg
+
+section .text
+    global _start
+
+_start:
+    write STDOUT_FILENO, msg, msg_len
+    exit 1


### PR DESCRIPTION
## Summary
- add a minimal assembly implementation for `iconv` that prints a not implemented message

## Testing
- `make`
- `make test` *(fails: bats missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846317b6c948328b0fd0c2f11694fc4