### PR TITLE
Implement chcon command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ python3 scripts/asmfmt.py src/example.asm
 - [`bc`](src/bc.asm) Arbitrary-precision arithmetic language
 - [`cat`](src/cat.asm) ✅ Concatenates and prints files
 - [`cd`](src/cd.asm) ✅ Changes the working directory
-- [`chcon`](src/chcon.asm) Changes file security context
+- [`chcon`](src/chcon.asm) ✅ Changes file security context
 - [`chgrp`](src/chgrp.asm) ✅ Changes file group ownership
 - [`chmod`](src/chmod.asm) ✅ Changes the permissions of a file or directory
 - [`chown`](src/chown.asm) ✅ Changes file ownership

--- a/include/defines.inc
+++ b/include/defines.inc
@@ -51,6 +51,7 @@
 
 %define SYS_CHROOT      161
 %define SYS_SYNC        162
+%define SYS_SETXATTR    188
 
 %define SYS_TIME        201
 

--- a/src/chcon.asm
+++ b/src/chcon.asm
@@ -1,0 +1,43 @@
+; src/chcon.asm
+
+%include "include/sysdefs.inc"
+
+section .data
+    usage_msg   db "Usage: chcon CONTEXT FILE", 10
+    usage_len   equ $ - usage_msg
+    fail_msg    db "chcon: setxattr failed", 10
+    fail_len    equ $ - fail_msg
+    attr_name   db "security.selinux", 0
+
+section .text
+    global _start
+
+_start:
+    pop     rcx             ; argc
+    cmp     rcx, 3
+    jne     .usage
+
+    pop     rax             ; discard argv[0]
+    pop     rsi             ; context string
+    pop     rdi             ; file path
+
+    call    strlen          ; length -> rbx
+
+    mov     rax, SYS_SETXATTR
+    mov     rdx, rsi        ; value
+    mov     rsi, attr_name  ; name
+    mov     r10, rbx        ; size
+    xor     r8, r8          ; flags
+    syscall
+
+    test    rax, rax
+    js      .fail
+    exit    0
+
+.usage:
+    write   STDOUT_FILENO, usage_msg, usage_len
+    exit    1
+
+.fail:
+    write   STDERR_FILENO, fail_msg, fail_len
+    exit    1

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -36,6 +36,12 @@ teardown(){ rm -rf "$TMP"; }
   assert_success
 }
 
+@test "chcon — sets security context" {
+  touch "$TMP/ctxfile"
+  run "$BIN/chcon" "dummy_u:dummy_r:dummy_t:s0" "$TMP/ctxfile"
+  assert_success
+}
+
 @test "chgrp — changes group ownership" {  
   touch "$TMP/testfile"    
   current_group=$(id -g)    


### PR DESCRIPTION
## Summary
- add chcon assembly implementation
- define SYS_SETXATTR syscall number
- mark chcon as implemented in README
- test chcon basic invocation

## Testing
- `make`
- `make test` *(fails: bats-support not found)*

------
https://chatgpt.com/codex/tasks/task_e_684630ec1ec48328b0f46752880234ed