### PR TITLE
Implement env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baloo 🐻 
 
-![Progress](https://img.shields.io/badge/progress-58%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-59%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 <center><img src="assets/Baloo.jpg" title=" भालू "></img></center>
@@ -63,7 +63,7 @@ python3 scripts/asmfmt.py src/example.asm
 - [`du`](src/du.asm) Shows disk usage on file systems
 - [`echo`](src/echo.asm) ✅ Displays a specified line of text
 - [`ed`](src/ed.asm) The standard text editor
-- [`env`](src/env.asm) Run a program in a modified environment
+- [`env`](src/env.asm) ✅ Run a program in a modified environment
 - [`expand`](src/expand.asm) ✅ Converts tabs to spaces
 - [`expr`](src/expr.asm) Evaluates expressions
 - [`factor`](src/factor.asm) ✅ Factors numbers

--- a/src/env.asm
+++ b/src/env.asm
@@ -1,0 +1,50 @@
+; src/env.asm
+
+    %include "include/sysdefs.inc"
+
+section .bss
+
+section .data
+exec_fail_msg db "env: execve failed", 10
+    exec_fail_len equ $ - exec_fail_msg
+    newline       db WHITESPACE_NL
+
+section .text
+global _start
+
+_start:
+    pop     rax                         ;argc
+    mov     rbx, rax
+    mov     r12, rsp                    ;argv
+    lea     r13, [r12 + rbx*8 + 8]      ;envp pointer
+
+    cmp     rbx, 1
+    jg      .has_command
+
+.print_env:
+    mov     r12, r13
+.print_loop:
+    mov     rsi, [r12]
+    test    rsi, rsi
+    je      .done
+
+    call    strlen                      ;length -> rbx
+    write   STDOUT_FILENO, rsi, rbx
+    write   STDOUT_FILENO, newline, 1
+
+    add     r12, 8
+    jmp     .print_loop
+
+.done:
+    exit    0
+
+.has_command:
+    pop     rdi                         ;skip program name
+    mov     rsi, rsp                    ;argv for execve (command and args)
+    mov     rdx, r13                    ;envp pointer
+    mov     rdi, [rsi]                  ;command path
+    mov     rax, SYS_EXECVE
+    syscall
+
+    write   STDERR_FILENO, exec_fail_msg, exec_fail_len
+    exit    1

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -209,6 +209,16 @@ teardown(){ rm -rf "$TMP"; }
   assert_output "$PATH"
 }
 
+@test "env — prints environment" {
+  run "$BIN/env"
+  [[ "$output" == *"PATH="* ]]
+}
+
+@test "env — executes command" {
+  run "$BIN/env" "$BIN/true"
+  assert_success
+}
+
 @test "pwd — matches $(pwd)" {
   pushd "$TMP" >/dev/null
   run "$BIN/pwd"


### PR DESCRIPTION
## Summary
- add env.asm implementation
- track env support in README
- expand test suite to cover env

## Testing
- `make test` *(fails: bats missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846313a56d083289e55e31037e4e0d0