### PR TITLE
Implement batch utility

### DIFF
--- a/Baloo.json
+++ b/Baloo.json
@@ -63,7 +63,7 @@
     "name": "batch",
     "description": "Schedules commands to be executed in a batch queue",
     "glyph": "📚",
-    "isDone": false
+    "isDone": true
   },
   {
     "name": "bc",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ python3 scripts/asmfmt.py src/example.asm
 - [`base64`](src/base64.asm) ✅ Prints a file's contents in Base64 to standard output
 - [`basename`](src/basename.asm) ✅ Removes the path prefix from a given pathname
 - [`basenc`](src/basenc.asm) Encodes or decodes various encodings and prints result to standard output
-- [`batch`](src/batch.asm) Schedules commands to be executed in a batch queue
+- [`batch`](src/batch.asm) Schedules commands to be executed in a batch queue ✅
 - [`bc`](src/bc.asm) Arbitrary-precision arithmetic language
 - [`cat`](src/cat.asm) ✅ Concatenates and prints files
 - [`cd`](src/cd.asm) ✅ Changes the working directory

--- a/src/batch.asm
+++ b/src/batch.asm
@@ -1,0 +1,62 @@
+; src/batch.asm
+
+%include "include/sysdefs.inc"
+
+%define CMD_BUF_SIZE 8192
+
+section .bss
+    cmd_buffer  resb CMD_BUF_SIZE
+
+section .data
+    sh_path     db "/bin/sh", 0
+    dash_c      db "-c", 0
+    exec_fail   db "Error: execve failed", WHITESPACE_NL
+    exec_fail_len equ $ - exec_fail
+
+section .text
+    global _start
+
+_start:
+    ; Retrieve argc and compute envp pointer
+    pop     rbx             ; argc
+    mov     rax, rsp        ; pointer to argv[0]
+    lea     r12, [rax + rbx*8 + 8]  ; envp pointer
+
+    ; Read commands from stdin
+    mov     r8, cmd_buffer          ; current buffer pointer
+    mov     r9, CMD_BUF_SIZE-1      ; remaining space
+
+.read_loop:
+    mov     rax, SYS_READ
+    mov     rdi, STDIN_FILENO
+    mov     rsi, r8
+    mov     rdx, r9
+    syscall
+    cmp     rax, 0
+    jle     .done_read
+    add     r8, rax
+    sub     r9, rax
+    cmp     r9, 0
+    jle     .done_read
+    jmp     .read_loop
+
+.done_read:
+    mov byte [r8], 0
+
+    ; Prepare argv array for execve("/bin/sh", ["sh","-c",cmd], envp)
+    sub     rsp, 32
+    mov     qword [rsp], sh_path    ; argv[0]
+    mov     qword [rsp+8], dash_c   ; argv[1]
+    lea     rax, [cmd_buffer]
+    mov     [rsp+16], rax           ; argv[2]
+    mov     qword [rsp+24], 0       ; NULL terminator
+
+    mov     rdi, sh_path
+    mov     rsi, rsp
+    mov     rdx, r12
+    mov     rax, SYS_EXECVE
+    syscall
+
+    ; If execve fails
+    write STDERR_FILENO, exec_fail, exec_fail_len
+    exit 1

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -19,6 +19,12 @@ teardown(){ rm -rf "$TMP"; }
   assert_success
   assert_output 'aGk='
 }
+@test "batch — runs stdin script" {
+  echo "echo hi" | run "$BIN/batch"
+  assert_success
+  assert_output "hi"
+}
+
 
 @test "basename — strips directories" {
   run "$BIN/basename" "/usr/local/bin/foo"


### PR DESCRIPTION
## Summary
- implement `batch` as a small wrapper that reads commands from stdin and executes them via `/bin/sh -c`
- mark `batch` as done in README and Baloo.json
- add a minimal test for the new command

## Testing
- `make test` *(fails: command "expand" failed, aborting)*

------
https://chatgpt.com/codex/tasks/task_e_684630ddd0fc8328bd271cda5a4208e7