### PR TITLE
Implement b2sum

### DIFF
--- a/Baloo.json
+++ b/Baloo.json
@@ -33,7 +33,7 @@
     "name": "b2sum",
     "description": "Computes and checks BLAKE2b message digest",
     "glyph": "🧪",
-    "isDone": false
+    "isDone": true
   },
   {
     "name": "base32",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ python3 scripts/asmfmt.py src/example.asm
 - [`arch`](src/arch.asm) ✅ Prints machine hardware name
 - [`at`](src/at.asm) ⛔️ Executes commands at a later time
 - [`awk`](src/awk.asm) ⛔️ Pattern scanning and processing language
-- [`b2sum`](src/b2sum.asm) ⛔️ Computes and checks BLAKE2b message digest
+- [`b2sum`](src/b2sum.asm) ✅ Computes and checks BLAKE2b message digest
  - [`base32`](src/base32.asm) ⛔️ Encodes or decodes Base32, and prints result to standard output
 - [`base64`](src/base64.asm) ⛔️ Prints a file's contents in Base64 to standard output
 - [`basename`](src/basename.asm) ✅ Removes the path prefix from a given pathname

--- a/src/b2sum.asm
+++ b/src/b2sum.asm
@@ -1,0 +1,134 @@
+; src/b2sum.asm
+
+%include "include/sysdefs.inc"
+
+%define BUFFER_SIZE 4096
+
+section .bss
+    buffer      resb BUFFER_SIZE        ; read buffer
+    digest      resb 64                 ; BLAKE2b result
+    hex_output  resb 128                ; hex string
+    newline     resb 1
+
+section .data
+    hex_chars   db "0123456789abcdef"
+
+    sockaddr:
+        dw AF_ALG                      ; salg_family
+        db 'hash',0,0,0,0,0,0,0,0,0,0   ; salg_type[14]
+        dd 0                           ; salg_feat
+        dd 0                           ; salg_mask
+        db 'blake2b',0
+        times (64-8) db 0
+    sockaddr_len equ $ - sockaddr
+
+section .text
+    global _start
+
+_start:
+    pop rcx                     ; argc
+    pop rbx                     ; argv[0]
+    dec rcx
+    jz  .use_stdin
+
+    pop rsi                     ; filename
+    mov rdi, STDIN_FILENO
+    call open_file
+    mov r14, rax                ; input fd
+    jmp .setup_socket
+
+.use_stdin:
+    mov r14, STDIN_FILENO
+
+.setup_socket:
+    mov rax, SYS_SOCKET
+    mov rdi, AF_ALG
+    mov rsi, SOCK_SEQPACKET
+    xor rdx, rdx
+    syscall
+    cmp rax, 0
+    jl  .error
+    mov r15, rax
+
+    mov rdi, r15
+    lea rsi, [rel sockaddr]
+    mov rdx, sockaddr_len
+    mov rax, SYS_BIND
+    syscall
+    cmp rax, 0
+    jl  .error
+
+    mov rdi, r15
+    xor rsi, rsi
+    xor rdx, rdx
+    mov rax, SYS_ACCEPT
+    syscall
+    cmp rax, 0
+    jl  .error
+    mov r13, rax                ; op fd
+
+.read_loop:
+    mov rax, SYS_READ
+    mov rdi, r14
+    mov rsi, buffer
+    mov rdx, BUFFER_SIZE
+    syscall
+    cmp rax, 0
+    jl  .error
+    je  .finish
+    mov rcx, rax
+    mov rax, SYS_WRITE
+    mov rdi, r13
+    mov rsi, buffer
+    mov rdx, rcx
+    syscall
+    cmp rax, 0
+    jl  .error
+    jmp .read_loop
+
+.finish:
+    mov rax, SYS_READ
+    mov rdi, r13
+    lea rsi, [digest]
+    mov rdx, 64
+    syscall
+    cmp rax, 0
+    jl  .error
+
+    cmp r14, STDIN_FILENO
+    je  .skip_close
+    mov rax, SYS_CLOSE
+    mov rdi, r14
+    syscall
+.skip_close:
+    mov rax, SYS_CLOSE
+    mov rdi, r13
+    syscall
+    mov rax, SYS_CLOSE
+    mov rdi, r15
+    syscall
+
+    ; convert digest to hex
+    lea rdi, [digest]
+    lea rsi, [hex_output]
+    mov rcx, 64
+.hex_loop:
+    movzx rax, byte [rdi]
+    mov rdx, rax
+    shr rdx, 4
+    mov bl, [hex_chars + rdx]
+    mov [rsi], bl
+    and al, 0xF
+    mov bl, [hex_chars + rax]
+    mov [rsi + 1], bl
+    inc rdi
+    add rsi, 2
+    loop .hex_loop
+
+    mov byte [newline], 10
+    write STDOUT_FILENO, hex_output, 128
+    write STDOUT_FILENO, newline, 1
+    exit 0
+
+.error:
+    exit 1

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -218,6 +218,12 @@ teardown(){ rm -rf "$TMP"; }
   assert_output '49f68a5c8493ec2c0bf489821c21fc3b'
 }
 
+@test "b2sum — digests stdin" {
+  run bash -c "printf 'hi' | \"$BIN/b2sum\""
+  assert_success
+  assert_output 'bfbcbe7ade93034ee0a41a2ea7b5fd81d89bdb1d75d1af230ea37d7abe71078f1df6db4d251cbc6b58e8963db2546f0f539c80b0f08c0fdd8c0a71075c97b3e7'
+}
+
 @test "mkdir — creates directory" {
   run "$BIN/mkdir" "$TMP/dir"
   assert_success


### PR DESCRIPTION
## Summary
- implement `b2sum` via `AF_ALG` hash sockets
- mark `b2sum` as complete in `README` and `Baloo.json`
- add a regression test for `b2sum`

## Testing
- `bats tests/test_all.bats` *(fails: base64 — encodes stdin)*

------
https://chatgpt.com/codex/tasks/task_e_6888ea1f90e4832890d1624d8aa0384d