### PR TITLE
Add basic `at` command

### DIFF
--- a/Baloo.json
+++ b/Baloo.json
@@ -21,7 +21,7 @@
     "name": "at",
     "description": "Executes commands at a later time",
     "glyph": "⏰",
-    "isDone": false
+    "isDone": true
   },
   {
     "name": "awk",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baloo 🐻 
 
-![Progress](https://img.shields.io/badge/progress-66%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-67%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 <center><img src="assets/Baloo.jpg" title=" भालू "></img></center>
@@ -30,7 +30,7 @@ python3 scripts/asmfmt.py src/example.asm
 - [`alias`](src/alias.asm) ✅ Defines or displays aliases
 - [`ar`](src/ar.asm) ✅ Creates and maintains libraries
 - [`arch`](src/arch.asm) ✅ Prints machine hardware name
-- [`at`](src/at.asm) ⛔️ Executes commands at a later time
+- [`at`](src/at.asm) ✅ Executes commands at a later time
 - [`awk`](src/awk.asm) ⛔️ Pattern scanning and processing language
 - [`b2sum`](src/b2sum.asm) ⛔️ Computes and checks BLAKE2b message digest
  - [`base32`](src/base32.asm) ⛔️ Encodes or decodes Base32, and prints result to standard output

--- a/src/at.asm
+++ b/src/at.asm
@@ -1,0 +1,99 @@
+; src/at.asm
+
+%include "include/sysdefs.inc"
+
+%define CMD_BUF_SIZE 8192
+
+section .bss
+    cmd_buffer  resb CMD_BUF_SIZE
+    ts_sec      resq 1
+    ts_nsec     resq 1
+
+section .data
+    sh_path     db "/bin/sh", 0
+    dash_c      db "-c", 0
+    usage_msg   db "Usage: at <seconds>\n", 0
+    usage_len   equ $ - usage_msg
+    exec_fail   db "Error: execve failed", WHITESPACE_NL
+    exec_fail_len equ $ - exec_fail
+
+section .text
+    global _start
+
+_start:
+    ; retrieve argc and envp
+    pop     rbx             ; argc
+    mov     rax, rsp        ; pointer to argv[0]
+    lea     r12, [rax + rbx*8 + 8]  ; envp pointer
+    dec     rbx
+    cmp     rbx, 1
+    jl      .usage
+
+    pop     rdi             ; seconds argument
+    call    str_to_int
+    mov     [ts_sec], rax
+
+    ; read commands from stdin
+    mov     r8, cmd_buffer
+    mov     r9, CMD_BUF_SIZE-1
+.read_loop:
+    mov     rax, SYS_READ
+    mov     rdi, STDIN_FILENO
+    mov     rsi, r8
+    mov     rdx, r9
+    syscall
+    cmp     rax, 0
+    jle     .done_read
+    add     r8, rax
+    sub     r9, rax
+    cmp     r9, 0
+    jle     .done_read
+    jmp     .read_loop
+.done_read:
+    mov     byte [r8], 0
+
+    ; sleep for the specified seconds
+    mov     rax, 35             ; SYS_nanosleep
+    lea     rdi, [ts_sec]
+    xor     rsi, rsi
+    syscall
+
+    ; prepare argv for execve("/bin/sh", ["sh","-c",cmd], envp)
+    sub     rsp, 32
+    mov     qword [rsp], sh_path
+    mov     qword [rsp+8], dash_c
+    lea     rax, [cmd_buffer]
+    mov     [rsp+16], rax
+    mov     qword [rsp+24], 0
+
+    mov     rdi, sh_path
+    mov     rsi, rsp
+    mov     rdx, r12
+    mov     rax, SYS_EXECVE
+    syscall
+
+    ; on failure
+    write STDERR_FILENO, exec_fail, exec_fail_len
+    exit 1
+
+.usage:
+    write STDERR_FILENO, usage_msg, usage_len
+    exit 1
+
+; Convert string in RDI to integer in RAX
+str_to_int:
+    xor rax, rax
+    xor rcx, rcx
+.next_digit:
+    movzx rcx, byte [rdi]
+    test rcx, rcx
+    jz .done
+    sub rcx, '0'
+    cmp rcx, 9
+    ja .done
+    imul rax, rax, 10
+    add rax, rcx
+    inc rdi
+    jmp .next_digit
+.done:
+    ret

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -25,6 +25,12 @@ teardown(){ rm -rf "$TMP"; }
   assert_output "hi"
 }
 
+@test "at — runs stdin script after delay" {
+  run bash -c "echo 'echo hi' | \"$BIN/at\" 0"
+  assert_success
+  assert_output "hi"
+}
+
 
 @test "base32 — encodes stdin" {
   run bash -c "printf 'hello' | \"$BIN/base32\""


### PR DESCRIPTION
## Summary
- implement a minimal `at` utility
- mark `at` as completed in README and Baloo.json
- add tests for `at`

## Testing
- `make`
- `bats -f "at — runs" tests/test_all.bats`
- `bats tests/test_all.bats` *(fails: `newgrp` and `nice` tests)*

------
https://chatgpt.com/codex/tasks/task_e_6888e9c1f82c83288d8a76a12d3bdacd