### PR TITLE
Implement strings command

### DIFF
--- a/Baloo.json
+++ b/Baloo.json
@@ -717,7 +717,7 @@
     "name": "strings",
     "description": "Find printable strings in files",
     "glyph": "🔤",
-    "isDone": false
+    "isDone": true
   },
   {
     "name": "stty",

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ python3 scripts/asmfmt.py src/example.asm
 - [`split`](src/split.asm) ⛔️ Splits a file into pieces
 - [`stat`](src/stat.asm) ⛔️ Returns data about an inode
 - [`stdbuf`](src/stdbuf.asm) ⛔️ Controls buffering for commands that use stdio
-- [`strings`](src/strings.asm) ⛔️ Find printable strings in files
+- [`strings`](src/strings.asm) ✅ Find printable strings in files
 - [`stty`](src/stty.asm) ⛔️ Changes and prints terminal line settings
 - [`sum`](src/sum.asm) ⛔️ Checksums and counts the blocks in a file
 - [`sync`](src/sync.asm) ✅ Flushes file system buffers

--- a/src/strings.asm
+++ b/src/strings.asm
@@ -1,0 +1,97 @@
+; src/strings.asm
+
+%include "include/sysdefs.inc"
+
+section .bss
+    bytebuf          resb 1                ; single byte buffer
+    strbuf      resb 1024             ; buffer for current string
+    fd          resq 1                ; file descriptor
+    len         resq 1                ; length of string in buffer
+
+section .data
+    usage_msg   db "Usage: strings [FILE]", WHITESPACE_NL
+    usage_len   equ $ - usage_msg
+    nl          db WHITESPACE_NL
+
+section .text
+    global _start
+
+_start:
+    pop     rbx                     ; argc
+    mov     qword [fd], STDIN_FILENO
+    pop     rax                     ; skip program name
+    dec     rbx
+    cmp     rbx, 0
+    jle     process
+    pop     rsi                     ; filename
+    dec     rbx
+    mov     rdi, STDIN_FILENO
+    call    open_file
+    mov     [fd], rax
+    cmp     rbx, 0
+    je      process
+    jmp     show_usage
+
+process:
+    xor     rcx, rcx                ; current length
+
+read_loop:
+    mov     rax, SYS_READ
+    mov     rdi, [fd]
+    mov     rsi, bytebuf
+    mov     rdx, 1
+    syscall
+    cmp     rax, 0
+    jle     eof
+
+    movzx   rax, byte [bytebuf]
+    cmp     al, 32
+    jl      flush
+    cmp     al, 126
+    jg      flush
+
+    mov     byte [strbuf + rcx], al
+    inc     rcx
+    cmp     rcx, 1023
+    jl      read_loop
+
+    ; buffer full, flush if long enough
+    mov     byte [strbuf + rcx], 0
+    cmp     rcx, 4
+    jl      reset
+    write   STDOUT_FILENO, strbuf, rcx
+    write   STDOUT_FILENO, nl, 1
+reset:
+    xor     rcx, rcx
+    jmp     read_loop
+
+flush:
+    mov     byte [strbuf + rcx], 0
+    cmp     rcx, 4
+    jl      clr
+    write   STDOUT_FILENO, strbuf, rcx
+    write   STDOUT_FILENO, nl, 1
+clr:
+    xor     rcx, rcx
+    jmp     read_loop
+
+eof:
+    mov     byte [strbuf + rcx], 0
+    cmp     rcx, 4
+    jl      close_fd
+    write   STDOUT_FILENO, strbuf, rcx
+    write   STDOUT_FILENO, nl, 1
+
+close_fd:
+    cmp     qword [fd], STDIN_FILENO
+    je      exit_success
+    mov     rax, SYS_CLOSE
+    mov     rdi, [fd]
+    syscall
+
+exit_success:
+    exit    0
+
+show_usage:
+    write   STDERR_FILENO, usage_msg, usage_len
+    exit    1

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -438,6 +438,12 @@ teardown(){ rm -rf "$TMP"; }
   assert_output 'foo'
 }
 
+@test "strings — extracts printable sequences" {
+  printf 'a\x00abcdEF\x01' >"$TMP/str"
+  run "$BIN/strings" "$TMP/str"
+  assert_output $'abcdEF\n'
+}
+
 @test "logger — logs message" {
   run "$BIN/logger" "hello"
   assert_success


### PR DESCRIPTION
## Summary
- implement `strings` utility to extract printable strings
- mark `strings` as done in `README.md` and `Baloo.json`
- test the new command in bats

## Testing
- `make build/strings.o`
- `make test` *(fails: bats reported missing libs or tests aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6888eb2f14b08328ab678e5b00c89bc5