### PR TITLE
Implement timeout command

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ python3 scripts/asmfmt.py src/example.asm
 - [`tee`](src/tee.asm) ✅ Sends output to multiple files
 - [`test`](src/test.asm) ⛔️ Evaluates an expression
 - [`time`](src/time.asm) ⛔️ Display elapsed, system and kernel time used by the current shell or designated process.
-- [`timeout`](src/timeout.asm) ⛔️ Runs a command with a time limit
+- [`timeout`](src/timeout.asm) ✅ Runs a command with a time limit
 - [`touch`](src/touch.asm) ✅ Changes file timestamps; creates file
 - [`tput`](src/tput.asm) ⛔️ Change terminal characteristics
 - [`tr`](src/tr.asm) ✅ Translates or deletes characters

--- a/src/timeout.asm
+++ b/src/timeout.asm
@@ -1,0 +1,58 @@
+; src/timeout.asm
+
+    %include "include/sysdefs.inc"
+
+section .data
+usage_msg       db "Usage: timeout SECS COMMAND [ARGS...]", 10
+    usage_len       equ $ - usage_msg
+exec_err_msg    db "timeout: exec failed", 10
+    exec_err_len    equ $ - exec_err_msg
+
+section .text
+global _start
+
+_start:
+    pop     rax                         ;argc
+    mov     rbx, rsp                    ;argv pointer
+    mov     r12, rax                    ;save argc
+    cmp     rax, 3
+    jl      .usage
+
+    mov     rsi, [rbx + 8]              ;argv[1] seconds
+    call    str_to_int
+
+    mov     rdi, rax                    ;seconds
+    mov     rax, 37                     ;SYS_alarm
+    syscall
+
+    lea     rdx, [rbx + r12*8 + 8]      ;env pointer
+    mov     rdi, [rbx + 16]             ;command
+    lea     rsi, [rbx + 16]             ;argv for command
+    mov     rax, SYS_EXECVE
+    syscall
+
+    write   STDERR_FILENO, exec_err_msg, exec_err_len
+    exit    1
+
+.usage:
+    write   STDERR_FILENO, usage_msg, usage_len
+    exit    1
+
+str_to_int:
+    xor     rax, rax
+    xor     rcx, rcx
+
+.next:
+    movzx   rdx, byte [rsi+rcx]
+    test    rdx, rdx
+    jz      .done
+    sub     rdx, '0'
+    cmp     rdx, 9
+    ja      .done
+    imul    rax, rax, 10
+    add     rax, rdx
+    inc     rcx
+    jmp     .next
+
+.done:
+    ret


### PR DESCRIPTION
## Summary
- add `timeout.asm` to run a command with a time limit
- mark `timeout` as implemented in the README

## Testing
- `make`
- `make test` *(fails: Executed 44 instead of expected 74 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6888eaae66708328b7468e91e21f75e5