### PR TITLE
Add tac command

### DIFF
--- a/Baloo.json
+++ b/Baloo.json
@@ -747,7 +747,7 @@
     "name": "tac",
     "description": "Concatenates and prints files in reverse order line by line",
     "glyph": "🙃",
-    "isDone": false
+    "isDone": true
   },
   {
     "name": "tail",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baloo 🐻 
 
-![Progress](https://img.shields.io/badge/progress-66%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-67%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 <center><img src="assets/Baloo.jpg" title=" भालू "></img></center>
@@ -151,7 +151,7 @@ python3 scripts/asmfmt.py src/example.asm
 - [`sum`](src/sum.asm) ⛔️ Checksums and counts the blocks in a file
 - [`sync`](src/sync.asm) ✅ Flushes file system buffers
 - [`tabs`](src/tabs.asm) ⛔️ Set terminal tabs
-- [`tac`](src/tac.asm) ⛔️ Concatenates and prints files in reverse order line by line
+- [`tac`](src/tac.asm) ✅ Concatenates and prints files in reverse order line by line
 - [`tail`](src/tail.asm) ✅ Output the end of files
 - [`tee`](src/tee.asm) ✅ Sends output to multiple files
 - [`test`](src/test.asm) ⛔️ Evaluates an expression

--- a/src/tac.asm
+++ b/src/tac.asm
@@ -1,0 +1,115 @@
+; src/tac.asm
+%include "include/sysdefs.inc"
+
+section .bss
+    buffer      resb 65536
+    line_pos    resq 8192
+    buffer_size equ 65536
+
+section .text
+    global _start
+
+_start:
+    pop r12             ; argc
+    pop rdi             ; skip program name
+    dec r12
+    cmp r12, 0
+    je read_stdin
+
+process_args:
+    cmp r12, 0
+    je exit_success
+    pop rdi             ; filename
+    call tac_file
+    dec r12
+    jmp process_args
+
+read_stdin:
+    mov rdi, STDIN_FILENO
+    call tac_fd
+    jmp exit_success
+
+; rdi = filename
+tac_file:
+    mov rax, SYS_OPEN
+    mov rsi, O_RDONLY
+    xor rdx, rdx
+    syscall
+    cmp rax, 0
+    jl error_exit
+    mov rdi, rax
+    push r12
+    call tac_fd
+    pop r12
+    mov rax, SYS_CLOSE
+    syscall
+    ret
+
+; rdi = file descriptor
+; reads file, stores line positions, outputs reversed
+; clobbers rax..r11
+
+tac_fd:
+    mov rax, SYS_READ
+    mov rsi, buffer
+    mov rdx, buffer_size
+    syscall
+    cmp rax, 0
+    jl error_exit
+    mov rbx, rax            ; bytes_read
+
+    mov qword [line_pos], 0 ; first line start index
+    mov rcx, 1              ; line count
+    xor r8, r8              ; current index
+
+.scan_loop:
+    cmp r8, rbx
+    jge .scan_done
+    mov al, [buffer + r8]
+    cmp al, 10
+    jne .not_nl
+    mov r9, rbx
+    dec r9
+    cmp r8, r9
+    je .not_nl              ; newline at end -> ignore
+    lea rax, [r8 + 1]
+    mov [line_pos + rcx*8], rax
+    inc rcx
+.not_nl:
+    inc r8
+    jmp .scan_loop
+
+.scan_done:
+    mov rdx, rcx            ; total lines -> rdx
+    dec rcx                 ; rcx = last index
+
+.output_loop:
+    cmp rcx, -1
+    jle .done
+    mov r9, [line_pos + rcx*8] ; start
+    mov r10, rcx
+    inc r10
+    cmp r10, rdx
+    jne .not_last
+    mov r11, rbx
+    jmp .write_line
+.not_last:
+    mov r11, [line_pos + r10*8]
+.write_line:
+    mov rax, SYS_WRITE
+    mov rdi, STDOUT_FILENO
+    lea rsi, [buffer + r9]
+    mov rdx, r11
+    sub rdx, r9
+    syscall
+    dec rcx
+    jmp .output_loop
+
+.done:
+    ret
+
+error_exit:
+    exit 1
+
+exit_success:
+    exit 0

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -336,6 +336,12 @@ teardown(){ rm -rf "$TMP"; }
   assert_output '3'
 }
 
+@test "tac — reverses line order" {
+  printf 'a\nb\nc\n' >"$TMP/tacfile"
+  run "$BIN/tac" "$TMP/tacfile"
+  assert_output $'c\nb\na\n'
+}
+
 @test "tee — duplicates stdin to file" {
   run bash -c "echo hi | \"$BIN/tee\" \"$TMP/out\""
   assert_success


### PR DESCRIPTION
## Summary
- implement `tac` in assembly
- update docs and metadata
- test reversing line order

## Testing
- `make build/tac.o`
- `make`
- `make test` *(fails: `newgrp` test and others; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6888eaa62560832889caa77f914cbb37