### PR TITLE
Align benchmark docs and script with repo bin layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Use `scripts/asmfmt.py` to keep assembly files consistent. By default it indents
 - [`xargs`](src/xargs.asm) ✅ Construct argument lists and invoke utility
 - [`yes`](src/yes.asm) ✅ Prints a string repeatedly
 ## Benchmark
-Run `make` to build all binaries, then execute `./benchmark.sh` to compare a few Baloo programs against the system implementations using `hyperfine`.
+Run `make` to build all binaries, then execute `tests/benchmark.sh` to compare a few Baloo programs against the system implementations using `hyperfine`.
 
 ## License
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/tests/benchmark.sh
+++ b/tests/benchmark.sh
@@ -1,9 +1,23 @@
 #!/usr/bin/env bash
 # Benchmark Baloo's assembly utilities against system utilities.
+#
+# Usage: run from any working directory after `make`; this script resolves
+# the repository root from its own location and uses <repo>/bin for Baloo binaries.
 
 set -e
 
-BALOOBIN="$(dirname "$0")/bin"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BALOOBIN="$REPO_ROOT/bin"
+
+
+# Verify every benchmarked Baloo command resolves to a built binary in bin/
+for cmd in cat echo true false base64; do
+  if [[ ! -x "$BALOOBIN/$cmd" ]]; then
+    echo "Missing benchmark binary: $BALOOBIN/$cmd. Run 'make' from repo root first." >&2
+    exit 1
+  fi
+done
 
 # Ensure hyperfine is installed
 if ! command -v hyperfine >/dev/null; then


### PR DESCRIPTION
### Motivation
- Ensure the benchmark script resolves Baloo binaries from the repository `bin/` directory regardless of the caller's working directory. 
- Make the README benchmark instructions match the actual script location and usage so contributors can run benchmarks reliably.

### Description
- Updated `README.md` benchmark section to instruct users to run `tests/benchmark.sh` instead of `./benchmark.sh`.
- Modified `tests/benchmark.sh` to compute `SCRIPT_DIR` and `REPO_ROOT` from the script location and set `BALOOBIN` to `$REPO_ROOT/bin` so the script is invocation-directory independent.
- Added a short usage note at the top of `tests/benchmark.sh` documenting that it can be run from any working directory after running `make`.
- Added a preflight check in `tests/benchmark.sh` that verifies the benchmarked commands (`cat`, `echo`, `true`, `false`, `base64`) exist as executables in `bin/` and fails early with a helpful message if not.

### Testing
- Ran `bash -n tests/benchmark.sh` to validate script syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f67090e00c8328b79c6b29eadf4bd7)