### PR TITLE
Fix catalog generation to avoid dead README source links

### DIFF
--- a/.github/workflows/Baloo.yml
+++ b/.github/workflows/Baloo.yml
@@ -32,6 +32,10 @@ jobs:
       # make clean is unnecessary on a fresh GitHub-hosted runner, went straight to make
       run: make
 
+
+    - name: Verify README catalog links
+      run: make check-readme-links
+
     - name: Run Tests
       timeout-minutes: 5
       # Removed the 'timeout' utility wrapper since GitHub Actions provides native step timeouts

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,6 @@ clean:
 
 test: all
 	bats --timing tests/test_all.bats
+
+check-readme-links:
+	python3 scripts/check_readme_links.py

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Use `scripts/asmfmt.py` to keep assembly files consistent. By default it indents
 - [`ar`](src/ar.asm) ✅ Creates and maintains libraries
 - [`arch`](src/arch.asm) ✅ Prints machine hardware name
 - [`at`](src/at.asm) ✅ Executes commands at a later time
-- [`awk`](src/awk.asm) ⛔️ Pattern scanning and processing language
+- `awk` ⛔️ Pattern scanning and processing language
 - [`b2sum`](src/b2sum.asm) ✅ Computes and checks BLAKE2b message digest
 - [`base32`](src/base32.asm) ✅ Encodes or decodes Base32, and prints result to standard output
 - [`base64`](src/base64.asm) ✅ Encodes or decodes Base64, and prints result to standard output
@@ -62,7 +62,7 @@ Use `scripts/asmfmt.py` to keep assembly files consistent. By default it indents
 - [`dirname`](src/dirname.asm) ✅ Strips non-directory suffix from file name
 - [`du`](src/du.asm) ✅ Shows disk usage on file systems
 - [`echo`](src/echo.asm) ✅ Displays a specified line of text
-- [`ed`](src/ed.asm) ⛔️ The standard text editor
+- `ed` ⛔️ The standard text editor
 - [`env`](src/env.asm) ✅ Run a program in a modified environment
 - [`expand`](src/expand.asm) ✅ Converts tabs to spaces
 - [`expr`](src/expr.asm) ✅ Evaluates expressions
@@ -95,7 +95,7 @@ Use `scripts/asmfmt.py` to keep assembly files consistent. By default it indents
 - [`lp`](src/lp.asm) ✅ Send files to a printer
 - [`ls`](src/ls.asm) ✅ List directory contents with formatting
 - [`m4`](src/m4.asm) ✅ Macro processor
-- [`mailx`](src/mailx.asm) ⛔️ Process messages
+- `mailx` ⛔️ Process messages
 - [`man`](src/man.asm) ✅ Display system documentation
 - [`md5sum`](src/md5sum.asm) ✅ Computes and checks MD5 message digest
 - [`mesg`](src/mesg.asm) ✅ Permit or deny messages
@@ -103,7 +103,7 @@ Use `scripts/asmfmt.py` to keep assembly files consistent. By default it indents
 - [`mkfifo`](src/mkfifo.asm) ✅ Makes named pipes (FIFOs)
 - [`mknod`](src/mknod.asm) ✅ Makes block or character special files
 - [`mktemp`](src/mktemp.asm) ✅ Creates a temporary file or directory
-- [`msgfmt`](src/msgfmt.asm) ⛔️ Create messages objects from messages object files
+- `msgfmt` ⛔️ Create messages objects from messages object files
 - [`mv`](src/mv.asm) ✅ Moves files or rename files
 - [`newgrp`](src/newgrp.asm) ✅ Change to a new group
 - [`ngettext`](src/ngettext.asm) ✅ Retrieve text string from messages object with plural form
@@ -113,41 +113,41 @@ Use `scripts/asmfmt.py` to keep assembly files consistent. By default it indents
 - [`nproc`](src/nproc.asm) ✅ Queries the number of (active) processors
 - [`numfmt`](src/numfmt.asm) ✅ Reformat numbers
 - [`od`](src/od.asm) ✅ Dumps files in octal and other formats
-- [`paste`](src/paste.asm) ⛔️ Merge corresponding or subsequent lines of files
-- [`patch`](src/patch.asm) ⛔️ Apply changes to files
-- [`pathchk`](src/pathchk.asm) ⛔️ Checks whether file names are valid or portable
-- [`pax`](src/pax.asm) ⛔️ Portable archive interchange
+- `paste` ⛔️ Merge corresponding or subsequent lines of files
+- `patch` ⛔️ Apply changes to files
+- `pathchk` ⛔️ Checks whether file names are valid or portable
+- `pax` ⛔️ Portable archive interchange
 - [`pinky`](src/pinky.asm) ✅ A lightweight version of finger
-- [`pr`](src/pr.asm) ⛔️ Paginate or columnate files for printing
+- `pr` ⛔️ Paginate or columnate files for printing
 - [`printenv`](src/printenv.asm) ✅ Prints environment variables
 - [`printf`](src/printf.asm) ✅ Formats and prints data
 - [`ps`](src/ps.asm) ✅ Report process status
-- [`ptx`](src/ptx.asm) ⛔️ Produces a permuted index of file contents
+- `ptx` ⛔️ Produces a permuted index of file contents
 - [`pwd`](src/pwd.asm) ✅ Prints the current working directory
-- [`read`](src/read.asm) ⛔️ Read a line from standard input
+- `read` ⛔️ Read a line from standard input
 - [`readlink`](src/readlink.asm) ✅ Print destination of a symbolic link
-- [`realpath`](src/realpath.asm) ⛔️ Returns the resolved absolute or relative path for a file
+- `realpath` ⛔️ Returns the resolved absolute or relative path for a file
 - [`renice`](src/renice.asm) ✅ Set nice values of running processes
 - [`rm`](src/rm.asm) ✅ Removes files/directories
 - [`rmdir`](src/rmdir.asm) ✅ Removes empty directories
-- [`runcon`](src/runcon.asm) ⛔️ Run command with specified security context
-- [`sed`](src/sed.asm) ⛔️ Stream editor
+- `runcon` ⛔️ Run command with specified security context
+- `sed` ⛔️ Stream editor
 - [`seq`](src/seq.asm) ✅ Prints a sequence of numbers
-- [`sh`](src/sh.asm) ⛔️ Shell, the standard command language interpreter
-- [`sha1sum`](src/sha1sum.asm) ⛔️ Computes and checks SHA-1/SHA-2 message digests
-- [`sha224sum`](src/sha224sum.asm) ⛔️ Computes and checks SHA-1/SHA-2 message digests
-- [`sha256sum`](src/sha256sum.asm) ⛔️ Computes and checks SHA-1/SHA-2 message digests
-- [`sha384sum`](src/sha384sum.asm) ⛔️ Computes and checks SHA-1/SHA-2 message digests
-- [`sha512sum`](src/sha512sum.asm) ⛔️ Computes and checks SHA-1/SHA-2 message digests
+- `sh` ⛔️ Shell, the standard command language interpreter
+- `sha1sum` ⛔️ Computes and checks SHA-1/SHA-2 message digests
+- `sha224sum` ⛔️ Computes and checks SHA-1/SHA-2 message digests
+- `sha256sum` ⛔️ Computes and checks SHA-1/SHA-2 message digests
+- `sha384sum` ⛔️ Computes and checks SHA-1/SHA-2 message digests
+- `sha512sum` ⛔️ Computes and checks SHA-1/SHA-2 message digests
 - [`shred`](src/shred.asm) ✅ Overwrites a file to hide its contents, and optionally deletes it
-- [`shuf`](src/shuf.asm) ⛔️ generates random permutations
+- `shuf` ⛔️ generates random permutations
 - [`sleep`](src/sleep.asm) ✅ Delays for a specified amount of time
-- [`sort`](src/sort.asm) ⛔️ Sorts lines of text files
+- `sort` ⛔️ Sorts lines of text files
 - [`split`](src/split.asm) ✅ Splits a file into pieces
-- [`stat`](src/stat.asm) ⛔️ Returns data about an inode
+- `stat` ⛔️ Returns data about an inode
 - [`stdbuf`](src/stdbuf.asm) ✅ Controls buffering for commands that use stdio
 - [`strings`](src/strings.asm) ✅ Find printable strings in files
-- [`stty`](src/stty.asm) ⛔️ Changes and prints terminal line settings
+- `stty` ⛔️ Changes and prints terminal line settings
 - [`sum`](src/sum.asm) ✅ Checksums and counts the blocks in a file
 - [`sync`](src/sync.asm) ✅ Flushes file system buffers
 - [`tabs`](src/tabs.asm) ✅ Set terminal tabs
@@ -158,7 +158,7 @@ Use `scripts/asmfmt.py` to keep assembly files consistent. By default it indents
 - [`time`](src/time.asm) ✅ Display elapsed, system and kernel time
 - [`timeout`](src/timeout.asm) ✅ Runs a command with a time limit
 - [`touch`](src/touch.asm) ✅ Changes file timestamps; creates file
-- [`tput`](src/tput.asm) ⛔️ Change terminal characteristics
+- `tput` ⛔️ Change terminal characteristics
 - [`tr`](src/tr.asm) ✅ Translates or deletes characters
 - [`true`](src/true.asm) ✅ Does nothing, but exits successfully
 - [`truncate`](src/truncate.asm) ✅ Shrink the size of a file to the specified size

--- a/scripts/check_readme_links.py
+++ b/scripts/check_readme_links.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Fail when README links point to missing src/*.asm files."""
+from pathlib import Path
+import re
+import sys
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    readme_path = repo_root / "README.md"
+    content = readme_path.read_text()
+
+    missing: list[str] = []
+    for rel_path in re.findall(r"\(src/([a-zA-Z0-9_+-]+\.asm)\)", content):
+        file_path = repo_root / "src" / rel_path
+        if not file_path.exists():
+            missing.append(f"src/{rel_path}")
+
+    if missing:
+        print("README has links to missing source files:")
+        for path in sorted(set(missing)):
+            print(f"- {path}")
+        return 1
+
+    print("README src/*.asm links are valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -5,10 +5,25 @@ import re
 from pathlib import Path
 
 
+def catalog_entry_line(entry: dict[str, object], src_dir: Path) -> str:
+    name = str(entry["name"])
+    asm_path = src_dir / f"{name}.asm"
+    status = "✅" if entry["isDone"] else "⛔️"
+    description = str(entry["description"])
+
+    if asm_path.exists():
+        name_rendered = f"[`{name}`](src/{name}.asm)"
+    else:
+        name_rendered = f"`{name}`"
+
+    return f"- {name_rendered} {status} {description}"
+
+
 def main() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     json_path = repo_root / "Baloo.json"
     readme_path = repo_root / "README.md"
+    src_dir = repo_root / "src"
 
     data = json.loads(json_path.read_text())
     total = len(data)
@@ -40,10 +55,7 @@ def main() -> None:
     if start is None or end is None:
         raise RuntimeError("Failed to locate catalog section in README")
 
-    catalog_lines = [
-        f"- [`{entry['name']}`](src/{entry['name']}.asm) {'✅' if entry['isDone'] else '⛔️'} {entry['description']}"
-        for entry in data
-    ]
+    catalog_lines = [catalog_entry_line(entry, src_dir) for entry in data]
 
     lines[start:end] = catalog_lines
     readme_path.write_text("\n".join(lines) + "\n")


### PR DESCRIPTION
### Motivation
- Prevent the README catalog from containing dead `src/*.asm` links when implementations are missing. 
- Preserve intentional placeholders in `Baloo.json` instead of deleting them, while making the rendered README safe and accurate.

### Description
- Update `scripts/update_readme.py` so catalog entries only render `src/<name>.asm` hyperlinks when the corresponding `src/<name>.asm` file exists and otherwise render the utility name as plain code text. 
- Add `scripts/check_readme_links.py` to statically validate that every `(src/*.asm)` link in `README.md` points to an existing file and exit non‑zero if not. 
- Add a `check-readme-links` target to the `Makefile` and run it in CI by adding a `Verify README catalog links` step to `.github/workflows/Baloo.yml`. 
- Regenerate `README.md` from `Baloo.json` so missing implementations (25 entries) are preserved as placeholders but no longer produce dead links.

### Testing
- Ran a quick count against `Baloo.json` to confirm `25` missing `src/*.asm` files and that none of those were marked `isDone: true`, and the check succeeded. 
- Ran `python3 scripts/update_readme.py` to regenerate `README.md` and the run completed successfully. 
- Ran `python3 scripts/check_readme_links.py` to verify README links and it reported that `README src/*.asm links are valid.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6708ba154832890541c01bf92d755)