### PR TITLE
Honor configurable test flags in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ BIN := $(patsubst src/%.asm,bin/%,$(SRC))
 
 FMT_FILES := $(SRC) $(INC)
 FMT_SCRIPT := scripts/asmfmt.py
+TEST_FLAGS ?= --timing
 
-.PHONY: all setup clean test format lint-format
+.PHONY: all setup clean test format lint-format check-readme-links
 
 all: setup $(BIN)
 
@@ -29,7 +30,7 @@ lint-format:
 	python3 -m compileall -q scripts/asmfmt.py
 
 test: all
-	bats --timing tests/test_all.bats
+	bats $(TEST_FLAGS) tests/test_all.bats
 
 check-readme-links:
 	python3 scripts/check_readme_links.py


### PR DESCRIPTION
### Motivation
- Make the `make test` target respect caller- provided Bats flags (so CI can pass flags like `--print-output-on-failure`) instead of hardcoding `--timing`.

### Description
- Add `TEST_FLAGS ?= --timing`, update the `test` recipe to run `bats $(TEST_FLAGS) tests/test_all.bats`, and add `check-readme-links` to `.PHONY` to ensure that recipe is always executed.

### Testing
- Ran `make -n test TEST_FLAGS="--timing --print-output-on-failure"`, `make lint-format`, and `make check-readme-links` which all succeeded, and attempted a full `make test TEST_FLAGS="--timing --print-output-on-failure"` which completed the build but the test run could not start because `bats` is not installed in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a219f055fcc8328921fed3e4c960be5)