### PR TITLE
Fix build-status badge to point at Baloo.yml workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Baloo 🐻 
 <img src="assets/Baloo.jpg" title=" भालू "></img>
 
-![Progress](https://img.shields.io/badge/progress-129%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-129%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/Baloo.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 


### PR DESCRIPTION
## What
The README "Build Status" badge pointed at `actions/workflows/makefile.yml/badge.svg`, but no `makefile.yml` workflow exists — the actual workflow is `.github/workflows/Baloo.yml`. The badge rendered as "no status". This points it at the correct workflow file.

## Change
`README.md` (line 4):
```diff
-![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
+![Build Status](https://github.com/seanwevans/baloo/actions/workflows/Baloo.yml/badge.svg)
```

## Verification
Documentation-only change; the referenced workflow file `.github/workflows/Baloo.yml` exists in the repo.

> Note: #170 also edits `README.md` (a different line); if both land, one may need a trivial rebase.

Closes #161

---
🤖 Generated with Claude Code — https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_