### PR TITLE
Make who/users use /run/utmp and accept explicit utmp file (fix #160)

### DIFF
--- a/src/users.asm
+++ b/src/users.asm
@@ -7,7 +7,7 @@ section .bss
     username    resb UT_NAMESIZE        ;username
 
 section .data
-    utmp_path   db "/var/run/utmp", 0   ;Path to the utmp file
+    default_utmp_path db "/run/utmp", 0 ;Default utmp file
     space       db " ", 0               ;Space delimiter between usernames
     newline     db 10, WHITESPACE_NL
 
@@ -15,8 +15,13 @@ section .text
 global      _start
 
 _start:
+    mov         rdi, default_utmp_path  ;Default path to the utmp file
+    cmp         qword [rsp], 2
+    jl          open_utmp
+    mov         rdi, [rsp + 16]         ;Optional FILE argument
+
+open_utmp:
     mov         rax, SYS_OPEN
-    mov         rdi, utmp_path          ;Path to the file
     mov         rsi, O_RDONLY           ;Read-only
     xor         rdx, rdx
     syscall

--- a/src/who.asm
+++ b/src/who.asm
@@ -6,10 +6,10 @@ section .bss
     utmp_buf        resb UTMP_SIZE
 
 section .data
-    utmp_file       db "/var/run/utmp", 0
-errmsg_open     db "Error: Cannot open /var/run/utmp", 10
+    default_utmp_file db "/run/utmp", 0
+errmsg_open     db "who: cannot open utmp file", 10
     errmsg_open_len equ $ - errmsg_open
-errmsg_read     db "Error: Cannot read /var/run/utmp", 10
+errmsg_read     db "who: cannot read utmp file", 10
     errmsg_read_len equ $ - errmsg_read
     newline         db WHITESPACE_NL
     tab             db 9
@@ -18,8 +18,13 @@ section .text
 global          _start
 
 _start:
+    mov             rdi, default_utmp_file
+    cmp             qword [rsp], 2
+    jl              .open_utmp
+    mov             rdi, [rsp + 16]     ;Optional FILE argument
+
+.open_utmp:
     mov             rax, SYS_OPEN
-    mov             rdi, utmp_file
     mov             rsi, O_RDONLY
     mov             rdx, 0
     syscall

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -6,6 +6,26 @@ load 'test_helper/bats-assert/load'
 setup()  { BIN="${BATS_TEST_DIRNAME}/../bin"; TMP=$(mktemp -d); }
 teardown(){ rm -rf "$TMP"; }
 
+make_utmp_fixture() {
+  local file="$1"
+  python3 - "$file" <<'PY'
+import struct
+import sys
+
+path = sys.argv[1]
+UTMP_SIZE = 384
+records = []
+for user, line, when in ((b"alice", b"pts/0", 1234567890), (b"bob", b"tty1", 1234567891)):
+    rec = bytearray(UTMP_SIZE)
+    struct.pack_into("<h", rec, 0, 7)
+    rec[8:8 + len(line)] = line
+    rec[44:44 + len(user)] = user
+    struct.pack_into("<I", rec, 340, when)
+    records.append(rec)
+open(path, "wb").write(b"".join(records))
+PY
+}
+
 # ----------  SINGLE‑TEST SMOKE CHECKS FOR EVERY ✅ PROGRAM ---------- #
 
 @test "arch — prints hardware name" {
@@ -477,10 +497,11 @@ teardown(){ rm -rf "$TMP"; }
   assert_output --partial "load"
 }
 
-@test "users — prints current user" {
-  skip "Temporarily disabled"
-  run "$BIN/users"
-  assert_output --partial "$(whoami)"
+@test "users — reads an explicit utmp file" {
+  make_utmp_fixture "$TMP/utmp"
+  run "$BIN/users" "$TMP/utmp"
+  assert_success
+  assert_output "alice bob"
 }
 
 @test "wc — counts lines" {
@@ -489,9 +510,12 @@ teardown(){ rm -rf "$TMP"; }
   assert_output "2 $TMP/w"
 }
 
-@test "who — lists users" {
-  run "$BIN/who"
+@test "who — reads an explicit utmp file" {
+  make_utmp_fixture "$TMP/utmp"
+  run "$BIN/who" "$TMP/utmp"
   assert_success
+  assert_output $'alice\tpts/0\t1234567890
+bob\ttty1\t1234567891'
 }
 
 @test "whoami — matches whoami(1)" {


### PR DESCRIPTION
### Motivation
- Replace hardcoded, deprecated `/var/run/utmp` usage and improve testability by allowing an explicit utmp file argument for the `who` and `users` utilities.
- Avoid embedding a concrete path in diagnostic strings so error messages remain generic and accurate across systems.

### Description
- Change both `users` and `who` to default to `/run/utmp` by introducing `default_utmp_path`/`default_utmp_file` and use that as the default when no `FILE` argument is provided in `src/users.asm` and `src/who.asm`.
- Allow an optional FILE argument by reading `argv[1]` (stack `rsp` lookup) and opening it when present, falling back to the default path otherwise.
- Update `who` error messages to not reference a hardcoded path and use generic messages like `who: cannot open utmp file` and `who: cannot read utmp file`.
- Add a `make_utmp_fixture` helper and replace the `users` and `who` smoke tests in `tests/test_all.bats` with tests that exercise reading an explicit utmp fixture file.
- Run repository formatting via `scripts/asmfmt.py` on the modified files.

### Testing
- Ran `make clean && make all` which completed successfully and produced `bin/users` and `bin/who`.
- Built `bin/users` and `bin/who` with `make setup bin/users bin/who` and ran manual fixture smoke tests that create a two-record UTMP file and executed `./bin/users <utmp>` and `./bin/who <utmp>`, both produced the expected output (tests passed).
- Ran `make lint-format` (format check) which succeeded.
- Attempted to run `bats --filter 'users|who' tests/test_all.bats` but `bats` was not available in the environment so the Bats suite could not be executed there.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a0c704bc832893867cdc648dc762)