### PR TITLE
asmfmt: make comment detection string-literal aware

### DIFF
--- a/scripts/asmfmt.py
+++ b/scripts/asmfmt.py
@@ -14,6 +14,31 @@ def normalize_whitespace_prefix(line: str) -> str:
     return expanded
 
 
+def find_comment(raw: str) -> int:
+    """Return the index of the comment-introducing ';' in ``raw``.
+
+    Semicolons that appear inside single-, double-, or back-quoted string
+    literals are not comment delimiters and are ignored. Back-quoted NASM
+    strings honour C-style backslash escapes. Returns -1 when there is no
+    comment on the line.
+    """
+    quote = None
+    escaped = False
+    for i, ch in enumerate(raw):
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif quote == '`' and ch == '\\':
+                escaped = True
+            elif ch == quote:
+                quote = None
+        elif ch in '"\'`':
+            quote = ch
+        elif ch == ';':
+            return i
+    return -1
+
+
 def format_line(line: str, indent: int, comment_col: int) -> str:
     raw = normalize_whitespace_prefix(line.rstrip('\n')).rstrip()
     stripped = raw.lstrip()
@@ -32,11 +57,11 @@ def format_line(line: str, indent: int, comment_col: int) -> str:
     if stripped.startswith(('section', 'global', 'extern')):
         return stripped
 
-    # Split code and comment
-    if ';' in raw:
-        code_part, comment_part = raw.split(';', 1)
-        code = code_part.strip()
-        comment = ';' + comment_part.strip()
+    # Split code and comment, ignoring ';' inside string literals
+    comment_idx = find_comment(raw)
+    if comment_idx != -1:
+        code = raw[:comment_idx].strip()
+        comment = ';' + raw[comment_idx + 1:].strip()
     else:
         code = raw.strip()
         comment = ''


### PR DESCRIPTION
## Problem
`scripts/asmfmt.py` `format_line()` separated code from comments by splitting on the first `;` with no awareness of string literals. Any `db`/`dw`/… line whose string contains a `;` would be silently corrupted by `make format`: the string was split at the `;`, the tail treated as a comment, re-indented and padded.

Reproduced before this change:
```
$ printf 'section .data\nfoo db "a;b", 10\n' > /tmp/x.asm && python3 scripts/asmfmt.py /tmp/x.asm
$ cat /tmp/x.asm
section .data
    foo db "a                           ;b", 10   # string destroyed
```
(It was latent only because the two existing in-string-`;` lines — `src/dircolors.asm:6`, `src/cmp.asm:26` — also contain a `:` that tripped the label regex first.)

## Fix
Add `find_comment()`, which scans the line and returns the index of the first **real** comment `;`, ignoring `;` inside single-, double-, or back-quoted string literals (back-quoted strings honour backslash escapes, matching NASM). `format_line()` now uses it instead of `raw.split(';', 1)`.

## Verification
```
# string with ';' and no ':' — previously corrupted, now preserved
foo db "a;b", 10            ->     foo db "a;b", 10
# in-string ';' AND a real trailing comment — split correctly + aligned
foo db "a;b", 0 ; real      ->     foo db "a;b", 0                     ;real
```
- `python3 -m compileall scripts/asmfmt.py` — OK
- `python3 scripts/asmfmt.py --check src/*.asm include/*.inc` → **exit 0**: this change reformats **zero** existing files (no churn), it only stops the corruption.

## Out of scope (follow-up)
The label-detection regex `^[^\s].*:` still treats any line containing a `:` as a label (e.g. a hypothetical `mov rax, [fs:0]`). No such line exists today, so it's left for a separate change to avoid reformatting `dircolors.asm`/`cmp.asm` here.

Closes #163

---
🤖 Generated with Claude Code — https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_