### PR TITLE
ci: enforce formatting with `make lint-format`

### DIFF
--- a/.github/workflows/Baloo.yml
+++ b/.github/workflows/Baloo.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Verify README catalog links
       run: make check-readme-links
 
+    - name: Check formatting
+      run: make lint-format
+
     - name: Run Tests
       timeout-minutes: 5
       # Removed the 'timeout' utility wrapper since GitHub Actions provides native step timeouts


### PR DESCRIPTION
## What
Adds a **Check formatting** step to `.github/workflows/Baloo.yml` that runs `make lint-format` (which runs `asmfmt.py --check` over all `src/*.asm` + `include/*.inc` and `compileall`s the formatter). The repo documents a canonical style and ships a `lint-format` target + a `.pre-commit-config.yaml` hook, but CI never exercised either, so style drift could land on `main`.

## Change
```diff
     - name: Verify README catalog links
       run: make check-readme-links
 
+    - name: Check formatting
+      run: make lint-format
+
     - name: Run Tests
```

## Verification
- `make lint-format` passes on current `main`, so this step is green today (no pre-existing violations to clean up).
- YAML parses; the job's steps are now: Checkout → Install deps → Install bats helpers → Compile → Verify README catalog links → **Check formatting** → Run Tests.

## Related
- #163 fixes a latent correctness bug in the same formatter. This PR doesn't depend on it (lint-format already passes), but landing #163 first means CI enforces the *fixed* formatter.

Closes #164

---
🤖 Generated with Claude Code — https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_