### PR TITLE
build: keep object files for incremental rebuilds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/*
+build/*
 *.txt
 *.log
 *.bak

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ TEST_FLAGS ?= --timing
 
 .PHONY: all setup clean test format lint-format check-readme-links
 
+# Preserve intermediate object files. Without this, GNU Make treats
+# build/%.o as an intermediate (made only to produce bin/%) and deletes
+# them after each build, forcing a full recompile every time.
+.SECONDARY: $(OBJ)
+
 all: setup $(BIN)
 
 setup:


### PR DESCRIPTION
## Problem
GNU Make treats `build/%.o` as *intermediate* files (made only to produce `bin/%`) and deletes them after each build. As a result `build/` is empty after `make`, and every `make` re-assembles all 129 sources from scratch — there's no incremental build.

## Fix
- Mark the objects `.SECONDARY: $(OBJ)` so Make keeps them.
- Add `build/*` to `.gitignore` (only `bin/*` was ignored before) so the now-retained objects don't appear as untracked.

```diff
 .PHONY: all setup clean test format lint-format check-readme-links

+# Preserve intermediate object files. Without this, GNU Make treats
+# build/%.o as an intermediate (made only to produce bin/%) and deletes
+# them after each build, forcing a full recompile every time.
+.SECONDARY: $(OBJ)
+
 all: setup $(BIN)
```

## Verification
```
$ make clean && make
$ ls build/*.o | wc -l      # 129  (previously 0)
$ make                      # recompiles nothing (only the phony `setup` mkdir runs)
```

> Note: #167 also edits `.gitignore` (it narrows the `*.txt` rule, a different line) — if both land, one may need a trivial rebase.

Closes #166

---
🤖 Generated with Claude Code — https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_