### PR TITLE
gitignore: drop blanket *.txt rule and stale fixasm.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 bin/*
-*.txt
 *.log
 *.bak
-
-fixasm.py


### PR DESCRIPTION
## Problem
`.gitignore` ignored `*.txt` repo-wide. Any text fixture or doc added anywhere is silently untracked — `git add foo.txt` does nothing and `git status` stays clean — which is an easy footgun for a coreutils-style project. The `fixasm.py` entry also references a file that's no longer in the repo.

## Why it's safe to remove
- `git ls-files '*.txt'` → 0 tracked `.txt` files (nothing depends on the rule).
- The test suite and `tests/benchmark.sh` write scratch data to `mktemp -d` directories, not in-repo, so no scratch `.txt` is produced in the tree.

## Change
```diff
 bin/*
-*.txt
 *.log
 *.bak
-
-fixasm.py
```
`*.log`/`*.bak` (unambiguous scratch) stay ignored. If scratch `.txt` output ever needs ignoring, prefer a dedicated directory (e.g. `tmp/`) over a repo-wide glob.

> Note: #166 also edits `.gitignore` (adds `build/*` near the top) — these hunks are adjacent, so whichever merges second will need a trivial rebase.

Closes #167

---
🤖 Generated with Claude Code — https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_