### PR TITLE
tests: skip root-sensitive chown/chgrp checks when running as root

### DIFF
--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -73,6 +73,10 @@ teardown(){ rm -rf "$TMP"; }
     skip "strace is required for syscall argument regression check"
   fi
 
+  if [ "$(id -u)" -eq 0 ]; then
+    skip "requires non-root: root may change group ownership freely, so chgrp will not fail"
+  fi
+
   touch "$TMP/testfile"
   gid=12345
   run strace -e trace=chown "$BIN/chgrp" "$gid" "$TMP/testfile"
@@ -90,6 +94,9 @@ teardown(){ rm -rf "$TMP"; }
 }
 
 @test "chown — (non‑root) returns EPERM" {
+  if [ "$(id -u)" -eq 0 ]; then
+    skip "requires non-root: root can change ownership without EPERM"
+  fi
   touch "$TMP/f"
   run "$BIN/chown" 0 "$TMP/f"
   assert_failure


### PR DESCRIPTION
## Problem
Two tests assume an unprivileged user and expect the kernel to reject ownership changes with `EPERM`:
- `chown — (non‑root) returns EPERM`
- `chgrp — passes parsed gid as chown gid argument`

When the suite runs as **root** (common in dev containers), those syscalls succeed, so the `assert_failure` checks fail — even though `chown`/`chgrp` behave correctly. (CI passes because GitHub runners are non-root.)

```
not ok 7 chgrp — passes parsed gid as chown gid argument
#   command succeeded, but it was expected to fail
not ok 9 chown — (non‑root) returns EPERM
#   command succeeded, but it was expected to fail
```

## Fix
Guard both tests with an `id -u == 0` check that `skip`s (rather than fails) under root. Non-root runs — including CI — are unaffected.

## Verification (run as root in this environment)
```
ok chgrp — changes group ownership
ok chgrp — passes parsed gid as chown gid argument # skip requires non-root: ...
ok chown — (non‑root) returns EPERM # skip requires non-root: ...
```
Both previously-failing tests now report `# skip` instead of `not ok`.

> Scope: this addresses only the root-assumption failures. The separately-tracked `who` failure on systems without `/var/run/utmp` (#160) is unrelated and not touched here.

Closes #168

---
🤖 Generated with Claude Code — https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_