### PR TITLE
docs: clarify the "no dependencies" claim re: utilities that exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 
 ![Progress](https://img.shields.io/badge/progress-129%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/makefile.yml/badge.svg)
 
-Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
+Just the bear utilities in x86_64 assembly using direct syscalls only — no libc and no external libraries.
+
+> A few utilities depend on an external program at runtime: `chroot`, `newgrp`, and `xargs`
+> exec a shell or command as part of their normal behavior, and `at`, `batch`, and `bc`
+> currently shell out (to `/bin/sh` and `/usr/bin/bc`).
 
 ## 🛠 Build Instructions
 simply run


### PR DESCRIPTION
## Problem
The README headline reads "direct syscalls only — **no libc or dependencies**", but several utilities `execve` external host binaries and won't work without them:

| Utility | Execs |
|---|---|
| `chroot`, `newgrp`, `xargs` | a shell/command (their normal semantics) |
| `at`, `batch` | `/bin/sh` |
| `bc` | `/usr/bin/bc` |

## Change
Reword the headline to "no libc and no external libraries" and add a short note listing the utilities that depend on an external program at runtime, so the claim is accurate.

```diff
-Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
+Just the bear utilities in x86_64 assembly using direct syscalls only — no libc and no external libraries.
+
+> A few utilities depend on an external program at runtime: `chroot`, `newgrp`, and `xargs`
+> exec a shell or command as part of their normal behavior, and `at`, `batch`, and `bc`
+> currently shell out (to `/bin/sh` and `/usr/bin/bc`).
```

Documentation-only. (`bc` being a pure wrapper is tracked separately in #159; this PR just documents current behavior.)

> Note: #161 also edits `README.md` (the badge on line 4, two lines above) — if both land, one may need a trivial rebase.

Closes #170

---
🤖 Generated with Claude Code — https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_