### PR TITLE
yes: repeat operands instead of always printing "y"

### DIFF
--- a/src/yes.asm
+++ b/src/yes.asm
@@ -2,16 +2,59 @@
 
     %include "include/sysdefs.inc"
 
+    %define BUF_SIZE 8192
+
 section .bss
+    buf     resb BUF_SIZE               ;assembled output line
 
 section .data
-    msg     db "y", 10
-    len     equ $ - msg
+    default_msg db "y", 10
+    default_len equ $ - default_msg
 
 section .text
 global  _start
 
 _start:
-.loop:
-    write   1, msg, len
-    jmp     .loop
+    mov     rax, [rsp]                  ;argc
+    cmp     rax, 1
+    jle     .use_default                ;no operands -> repeat "y"
+
+    lea     r12, [rsp + 16]             ;&argv[1]
+    mov     r13, rax
+    dec     r13                         ;operand count (argc - 1)
+    xor     rbx, rbx                    ;output length / write offset
+    xor     r14, r14                    ;current operand index
+
+.next_arg:
+    mov     rsi, [r12 + r14*8]          ;argv[1 + r14]
+.copy_byte:
+    mov     al, [rsi]
+    test    al, al
+    jz      .arg_copied
+    cmp     rbx, BUF_SIZE - 2           ;leave room for separator + newline
+    jae     .terminate
+    mov     [buf + rbx], al
+    inc     rbx
+    inc     rsi
+    jmp     .copy_byte
+.arg_copied:
+    inc     r14
+    cmp     r14, r13
+    jae     .terminate                  ;last operand copied
+    cmp     rbx, BUF_SIZE - 2
+    jae     .terminate
+    mov     byte [buf + rbx], ' '       ;separate operands with a space
+    inc     rbx
+    jmp     .next_arg
+
+.terminate:
+    mov     byte [buf + rbx], 10        ;trailing newline
+    inc     rbx
+
+.loop_line:
+    write   STDOUT_FILENO, buf, rbx
+    jmp     .loop_line
+
+.use_default:
+    write   STDOUT_FILENO, default_msg, default_len
+    jmp     .use_default


### PR DESCRIPTION
## Problem
`src/yes.asm` always wrote the hardcoded `y\n` and ignored `argv`. Real `yes` repeats its operand(s): `yes foo` prints `foo` forever, `yes a b` prints `a b`.

## Fix
Build the output line once from `argv[1..]` — operands joined with single spaces and a trailing newline, into an 8 KiB `.bss` buffer with bounds checks — then loop writing it. With no operands, fall back to repeating `y` as before.

## Verification
```
$ yes hello | head -3        $ yes a b c | head -1        $ yes | head -2
hello                        a b c                        y
hello                                                     y
hello
$ yes "" | head -2 | cat -A   # empty operand -> empty lines
$
$
```
- Assembles with `nasm -f elf64 -w+all` — no warnings.
- `python3 scripts/asmfmt.py --check src/yes.asm` — clean (so it passes the formatting check proposed in #164).
- Output stops on `SIGPIPE` (e.g. piped into `head`), same as the original.

Closes #171

---
🤖 Generated with Claude Code — https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_