### PR TITLE
exec: search PATH (execvp-style) and honor $SHELL across exec utilities

### DIFF
--- a/include/sysdefs.inc
+++ b/include/sysdefs.inc
@@ -4,6 +4,7 @@
     %include "include/macros.inc"
 
 section .bss
+    __path_buf resb 4096
 
 section .text
 global open_file
@@ -17,6 +18,10 @@ section .data
     error_msg_read_len equ $ - error_msg_read
     error_msg_write db "Error writing file", 10
     error_msg_write_len equ $ - error_msg_write
+    __path_prefix db "PATH=", 0
+__default_path db "/usr/bin:/bin", 0
+    __shell_prefix db "SHELL=", 0
+    __default_shell db "/bin/sh", 0
 
 section .text
 
@@ -64,4 +69,124 @@ strlen:
     inc rbx
     jmp .loop
 .done:
+    ret
+
+; __find_env: return a pointer to an environment variable's value.
+;   rdi = "NAME=" prefix (NUL-terminated, includes the '=')
+;   rsi = envp (NULL-terminated array of char*)
+;   returns rax = pointer just past the '=', or 0 when the var is absent.
+;   clobbers rax, rcx, r8, r9
+__find_env:
+    mov r8, rsi
+.fe_loop:
+    mov r9, [r8]
+    test r9, r9
+    jz .fe_none
+    mov rcx, rdi
+.fe_cmp:
+    mov al, [rcx]
+    test al, al
+    jz .fe_found
+    cmp al, [r9]
+    jne .fe_next
+    inc rcx
+    inc r9
+    jmp .fe_cmp
+.fe_next:
+    add r8, 8
+    jmp .fe_loop
+.fe_found:
+    mov rax, r9
+    ret
+.fe_none:
+    xor rax, rax
+    ret
+
+; __path_execve: execve a program, searching PATH like execvp(3) when the
+;                program name contains no slash.
+;   rdi = program name (NUL-terminated)
+;   rsi = argv (NULL-terminated) for the new image
+;   rdx = envp (NULL-terminated)
+;   returns ONLY on failure (every candidate failed); clobbers r8-r15, etc.
+__path_execve:
+    mov r12, rdi
+    mov r13, rsi
+    mov r14, rdx
+    mov rcx, r12
+.scan_slash:
+    mov al, [rcx]
+    test al, al
+    jz .no_slash
+    cmp al, '/'
+    je .direct
+    inc rcx
+    jmp .scan_slash
+.direct:
+    mov rdi, r12
+    mov rsi, r13
+    mov rdx, r14
+    mov rax, SYS_EXECVE
+    syscall
+    ret
+.no_slash:
+    mov rdi, __path_prefix
+    mov rsi, r14
+    call __find_env
+    test rax, rax
+    jnz .have_path
+    mov rax, __default_path
+.have_path:
+    mov r15, rax
+.entry_loop:
+    mov rdi, __path_buf
+    mov r8, r15
+    xor rcx, rcx
+.copy_entry:
+    mov al, [r8]
+    test al, al
+    jz .entry_done
+    cmp al, 58
+    je .entry_done
+    cmp rcx, 4000
+    jae .skip_overflow
+    mov [rdi], al
+    inc rdi
+    inc r8
+    inc rcx
+    jmp .copy_entry
+.skip_overflow:
+    mov al, [r8]
+    test al, al
+    jz .entry_done
+    cmp al, 58
+    je .entry_done
+    inc r8
+    jmp .skip_overflow
+.entry_done:
+    test rcx, rcx
+    jz .append_name
+    mov byte [rdi], '/'
+    inc rdi
+.append_name:
+    mov r9, r12
+.copy_name:
+    mov al, [r9]
+    mov [rdi], al
+    test al, al
+    jz .try_exec
+    inc rdi
+    inc r9
+    jmp .copy_name
+.try_exec:
+    mov rdi, __path_buf
+    mov rsi, r13
+    mov rdx, r14
+    mov rax, SYS_EXECVE
+    syscall
+    mov al, [r8]
+    test al, al
+    jz .exhausted
+    lea r15, [r8 + 1]
+    jmp .entry_loop
+.exhausted:
     ret

--- a/src/at.asm
+++ b/src/at.asm
@@ -10,7 +10,6 @@ section .bss
     ts_nsec     resq 1
 
 section .data
-    sh_path     db "/bin/sh", 0
     dash_c      db "-c", 0
 usage_msg   db "Usage: at <seconds>\n", 0
     usage_len   equ $ - usage_msg
@@ -58,19 +57,25 @@ _start:
     xor     rsi, rsi
     syscall
 
-; prepare argv for execve("/bin/sh", ["sh","-c",cmd], envp)
+; resolve shell ($SHELL, else /bin/sh) and exec ["sh","-c",cmd]
+    mov     rdi, __shell_prefix
+    mov     rsi, r12
+    call    __find_env
+    test    rax, rax
+    jnz     .have_shell
+    mov     rax, __default_shell
+.have_shell:
     sub     rsp, 32
-    mov     qword [rsp], sh_path
-    mov     qword [rsp+8], dash_c
-    lea     rax, [cmd_buffer]
-    mov     [rsp+16], rax
+    mov     [rsp], rax                  ;argv[0] = shell
+    mov     qword [rsp+8], dash_c       ;argv[1] = -c
+    lea     rcx, [cmd_buffer]
+    mov     [rsp+16], rcx               ;argv[2] = command
     mov     qword [rsp+24], 0
 
-    mov     rdi, sh_path
+    mov     rdi, [rsp]
     mov     rsi, rsp
     mov     rdx, r12
-    mov     rax, SYS_EXECVE
-    syscall
+    call    __path_execve
 
 ; on failure
     write STDERR_FILENO, exec_fail, exec_fail_len

--- a/src/batch.asm
+++ b/src/batch.asm
@@ -8,7 +8,6 @@ section .bss
     cmd_buffer  resb CMD_BUF_SIZE
 
 section .data
-    sh_path     db "/bin/sh", 0
     dash_c      db "-c", 0
 exec_fail   db "Error: execve failed", WHITESPACE_NL
     exec_fail_len equ $ - exec_fail
@@ -43,19 +42,25 @@ _start:
 .done_read:
     mov byte [r8], 0
 
-; Prepare argv array for execve("/bin/sh", ["sh","-c",cmd], envp)
+; resolve shell ($SHELL, else /bin/sh) and exec ["sh","-c",cmd]
+    mov     rdi, __shell_prefix
+    mov     rsi, r12
+    call    __find_env
+    test    rax, rax
+    jnz     .have_shell
+    mov     rax, __default_shell
+.have_shell:
     sub     rsp, 32
-    mov     qword [rsp], sh_path        ;argv[0]
-    mov     qword [rsp+8], dash_c       ;argv[1]
-    lea     rax, [cmd_buffer]
-    mov     [rsp+16], rax               ;argv[2]
+    mov     [rsp], rax                  ;argv[0] = shell
+    mov     qword [rsp+8], dash_c       ;argv[1] = -c
+    lea     rcx, [cmd_buffer]
+    mov     [rsp+16], rcx               ;argv[2] = command
     mov     qword [rsp+24], 0           ;NULL terminator
 
-    mov     rdi, sh_path
+    mov     rdi, [rsp]
     mov     rsi, rsp
     mov     rdx, r12
-    mov     rax, SYS_EXECVE
-    syscall
+    call    __path_execve
 
 ; If execve fails
     write STDERR_FILENO, exec_fail, exec_fail_len

--- a/src/chroot.asm
+++ b/src/chroot.asm
@@ -17,7 +17,6 @@ chdir_fail_msg  db "Error: chdir failed", 10, 0
     chdir_fail_len  equ $ - chdir_fail_msg
 not_root_msg    db "Error: Must be run as root (UID 0)", 10, 0
     not_root_len    equ $ - not_root_msg
-    shell_path      db "/bin/sh", 0
     root_path       db "/", 0
 
 section .text
@@ -54,15 +53,20 @@ _start:
     cmp             r10, 3              ;If argc >= 3, we have a command to execute
     jge             exec_command
 
-    sub             rsp, 24             ;Space for 3 pointers (NULL terminated)
-mov             rdi, shell_path     ; First argument: path to shell
-    mov             [rsp], rdi          ;argv[0] = shell_path
-    mov             QWORD [rsp+8], 0    ;argv[1] = NULL
-mov             rsi, rsp            ; Second argument: argv array
-mov             rdx, [env_ptr]      ; Third argument: environment variables
-
-    mov             rax, SYS_EXECVE
-    syscall
+    sub             rsp, 24
+    mov             rdi, __shell_prefix
+    mov             rsi, [env_ptr]
+    call            __find_env
+    test            rax, rax
+    jnz             .have_shell
+    mov             rax, __default_shell
+.have_shell:
+    mov             [rsp], rax
+    mov             qword [rsp+8], 0
+    mov             rdi, rax
+    mov             rsi, rsp
+    mov             rdx, [env_ptr]
+    call            __path_execve
 
     jmp             execve_error
 
@@ -73,8 +77,7 @@ exec_command:
     mov             rdi, [rbx]          ;command path
     mov             rdx, [env_ptr]      ;envp
 
-    mov             rax, SYS_EXECVE
-    syscall
+    call            __path_execve
 
     jmp             execve_error
 

--- a/src/command.asm
+++ b/src/command.asm
@@ -21,8 +21,7 @@ _start:
     add     rbx, 8                      ;skip program name
     mov     rsi, rbx                    ;argv for execve
     mov     rdi, [rsi]                  ;command path
-    mov     rax, SYS_EXECVE
-    syscall
+    call    __path_execve
 
     write   STDERR_FILENO, execve_fail_msg, execve_fail_len
     exit    1

--- a/src/env.asm
+++ b/src/env.asm
@@ -43,8 +43,7 @@ _start:
     mov     rsi, rsp                    ;argv for execve (command and args)
     mov     rdx, r13                    ;envp pointer
     mov     rdi, [rsi]                  ;command path
-    mov     rax, SYS_EXECVE
-    syscall
+    call    __path_execve
 
     write   STDERR_FILENO, exec_fail_msg, exec_fail_len
     exit    1

--- a/src/newgrp.asm
+++ b/src/newgrp.asm
@@ -12,7 +12,6 @@ setgid_fail_msg db "Error: setgid failed", 10
     setgid_fail_len equ $ - setgid_fail_msg
 exec_fail_msg   db "Error: execve failed", 10
     exec_fail_len   equ $ - exec_fail_msg
-    shell_path      db "/bin/sh", 0
 
 section .text
 global _start
@@ -38,14 +37,20 @@ _start:
     cmp r10, 2
     jg exec_command
 
-    sub rsp, 24                         ;space for argv[0], argv[1], NULL
-    mov rdi, shell_path
-    mov [rsp], rdi
+    mov rdi, __shell_prefix
+    mov rsi, [env_ptr]
+    call __find_env
+    test rax, rax
+    jnz .have_shell
+    mov rax, __default_shell
+.have_shell:
+    sub rsp, 24                         ;space for argv[0], NULL
+    mov [rsp], rax
     mov qword [rsp+8], 0
+    mov rdi, rax
     mov rsi, rsp
     mov rdx, [env_ptr]
-    mov rax, SYS_EXECVE
-    syscall
+    call __path_execve
     jmp exec_error
 
 exec_command:
@@ -53,8 +58,7 @@ exec_command:
     mov rsi, rbx                        ;argv array for command
     mov rdi, [rbx]                      ;command path
     mov rdx, [env_ptr]
-    mov rax, SYS_EXECVE
-    syscall
+    call __path_execve
     jmp exec_error
 
 usage_error:

--- a/src/nice.asm
+++ b/src/nice.asm
@@ -45,7 +45,9 @@ _start:
     jl      .usage
     add     rdx, 8                      ;value string
     mov     rdi, [rdx]
+    push    rdx                         ;parse_number clobbers rdx
     call    parse_number
+    pop     rdx
     cmp     rax, -1
     je      .usage
     mov     [adjust], rax
@@ -73,8 +75,7 @@ _start:
     mov     rdi, [rdx]
     mov     rsi, rdx
     mov     rdx, [env_ptr]
-    mov     rax, SYS_EXECVE
-    syscall
+    call    __path_execve
 
 .exec_error:
     write   STDERR_FILENO, exec_err_msg, exec_err_len

--- a/src/nohup.asm
+++ b/src/nohup.asm
@@ -67,8 +67,7 @@ _start:
     mov     rdi, [rbx + 8]
     lea     rsi, [rbx + 8]
     mov     rdx, r13
-    mov     rax, SYS_EXECVE
-    syscall
+    call    __path_execve
 
     write   STDERR_FILENO, exec_fail, exec_fail_len
     exit    1

--- a/src/stdbuf.asm
+++ b/src/stdbuf.asm
@@ -197,8 +197,7 @@ copy_env:
     mov     rdx, r9
 
 exec_cmd:
-    mov     rax, SYS_EXECVE
-    syscall
+    call    __path_execve
 
 show_usage:
     write   STDERR_FILENO, usage_msg, usage_len

--- a/src/time.asm
+++ b/src/time.asm
@@ -85,8 +85,7 @@ _start:
     mov     rsi, [argv_ptr]
     mov     rdx, [env_ptr]
     mov     rdi, [rsi]                  ;command path
-    mov     rax, SYS_EXECVE
-    syscall
+    call    __path_execve
 
     write   STDERR_FILENO, exec_err, exec_err_len
     exit    1

--- a/src/timeout.asm
+++ b/src/timeout.asm
@@ -28,8 +28,7 @@ _start:
     lea     rdx, [rbx + r12*8 + 8]      ;env pointer
     mov     rdi, [rbx + 16]             ;command
     lea     rsi, [rbx + 16]             ;argv for command
-    mov     rax, SYS_EXECVE
-    syscall
+    call    __path_execve
 
     write   STDERR_FILENO, exec_err_msg, exec_err_len
     exit    1

--- a/src/xargs.asm
+++ b/src/xargs.asm
@@ -10,7 +10,7 @@ section .bss
     arg_list    resq MAX_ARGS + 1       ;pointers to args
 
 section .data
-    default_cmd db "/bin/echo", 0
+    default_cmd db "echo", 0
 exec_fail   db "xargs: exec failed", WHITESPACE_NL
     exec_fail_len equ $ - exec_fail
 
@@ -103,8 +103,7 @@ _start:
     mov     rdi, [arg_list]
     mov     rsi, arg_list
     mov     rdx, r12
-    mov     rax, SYS_EXECVE
-    syscall
+    call    __path_execve
 
     write   STDERR_FILENO, exec_fail, exec_fail_len
     exit    1


### PR DESCRIPTION
## Problem
Utilities that run another program passed the command straight to `execve(2)`. Unlike `execvp(3)`, `execve` does **not** search `$PATH`, so a bare command name (`nice ls`, `env make`, …) failed with `ENOENT`; only absolute/relative paths worked. The shell-launchers additionally hardcoded `/bin/sh` or `/bin/echo`.

This addresses all 12 exec issues in one change because they share a single root cause and fix — a copy-pasted ~90-line routine across 12 separately-merging branches would conflict and be far worse to review.

## Change
Two shared helpers added to `include/sysdefs.inc` (which already hosts `strlen`/`open_file`):
- **`__find_env`** — minimal `getenv` (locate `"NAME="` in `envp`).
- **`__path_execve`** — `execvp`-style exec: direct when the name contains `/`, otherwise searches each `$PATH` entry (default `/usr/bin:/bin` when `PATH` is unset), building candidates in a bounded buffer.

Wiring:
- **PATH search** (`__path_execve`): `env`, `command`, `nice`, `nohup`, `stdbuf`, `time`, `timeout`, `chroot` — closes #186–#193.
- **Honor `$SHELL`** (fallback `/bin/sh`), dropping hardcoded paths: `at`, `batch`, `newgrp`, `chroot`; **`xargs`** now defaults to `echo` resolved via PATH instead of hardcoded `/bin/echo` — closes #194–#197.

### Bonus fix
`nice -n N CMD` segfaulted (pre-existing): `parse_number` clobbers `rdx` (the argv cursor), corrupting the command pointer. Preserved `rdx` across the call so `nice -n` works at all.

## Verification
- All **129** binaries build with `nasm -w+all` → no warnings; `make lint-format` clean.
- Behavior-tested every changed utility with both a **bare** (PATH-resolved) and an **absolute** command, e.g. `env echo hi`→`hi`, `nice -n 5 echo`→ works, `xargs`→default echo, `at 0`→runs `/bin/sh -c`, `at` honors `$SHELL`, `newgrp $(id -g) echo`, `chroot / echo`.
- Full bats suite: **no new failures** (the 3 remaining — chown/chgrp under root, who/utmp — are pre-existing and handled by #182 and the upcoming who/utmp PR).

> Out of scope: `nice`'s priority *value* math looks off (it treats `getpriority`'s `20−nice` return as the nice value); flagged for a separate issue, not changed here.

Closes #186, #187, #188, #189, #190, #191, #192, #193, #194, #195, #196, #197

---
🤖 Generated with Claude Code — https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_