### PR TITLE
who/users: prefer /run/utmp, fall back to /var/run/utmp, tolerate missing utmp

### DIFF
--- a/src/users.asm
+++ b/src/users.asm
@@ -7,7 +7,8 @@ section .bss
     username    resb UT_NAMESIZE        ;username
 
 section .data
-    utmp_path   db "/var/run/utmp", 0   ;Path to the utmp file
+    utmp_run    db "/run/utmp", 0       ;Modern utmp path
+    utmp_path   db "/var/run/utmp", 0   ;Legacy utmp path
     space       db " ", 0               ;Space delimiter between usernames
     newline     db 10, WHITESPACE_NL
 
@@ -16,14 +17,22 @@ global      _start
 
 _start:
     mov         rax, SYS_OPEN
-    mov         rdi, utmp_path          ;Path to the file
-    mov         rsi, O_RDONLY           ;Read-only
+    mov         rdi, utmp_run           ;Try modern path first
+    mov         rsi, O_RDONLY
     xor         rdx, rdx
     syscall
-
     test        rax, rax
-    js          exit_error              ;(error)
+    jns         opened
 
+    mov         rax, SYS_OPEN
+    mov         rdi, utmp_path          ;Fall back to legacy path
+    mov         rsi, O_RDONLY
+    xor         rdx, rdx
+    syscall
+    test        rax, rax
+    js          no_utmp                 ;No utmp -> no logged-in users
+
+opened:
     mov         r15, rax
 
 read_loop:
@@ -91,3 +100,6 @@ end_read:
 
 exit_error:
     exit        1
+
+no_utmp:
+    exit        0

--- a/src/who.asm
+++ b/src/who.asm
@@ -6,10 +6,9 @@ section .bss
     utmp_buf        resb UTMP_SIZE
 
 section .data
+    utmp_run        db "/run/utmp", 0
     utmp_file       db "/var/run/utmp", 0
-errmsg_open     db "Error: Cannot open /var/run/utmp", 10
-    errmsg_open_len equ $ - errmsg_open
-errmsg_read     db "Error: Cannot read /var/run/utmp", 10
+errmsg_read     db "Error: Cannot read utmp", 10
     errmsg_read_len equ $ - errmsg_read
     newline         db WHITESPACE_NL
     tab             db 9
@@ -19,14 +18,22 @@ global          _start
 
 _start:
     mov             rax, SYS_OPEN
-    mov             rdi, utmp_file
+    mov             rdi, utmp_run       ;try modern path first
     mov             rsi, O_RDONLY
     mov             rdx, 0
     syscall
-
     cmp             rax, 0
-    jl              .open_error
+    jge             .opened
 
+    mov             rax, SYS_OPEN
+    mov             rdi, utmp_file      ;fall back to legacy path
+    mov             rsi, O_RDONLY
+    mov             rdx, 0
+    syscall
+    cmp             rax, 0
+    jl              .no_utmp            ;no utmp -> no logged-in users
+
+.opened:
     mov             r12, rax            ;file descriptor
 
 .read_loop:
@@ -87,13 +94,8 @@ _start:
     syscall
     exit            0
 
-.open_error:
-    mov             rax, SYS_WRITE
-    mov             rdi, STDERR_FILENO
-    mov             rsi, errmsg_open
-    mov             rdx, errmsg_open_len
-    syscall
-    exit            1
+.no_utmp:
+    exit            0
 
 .read_error:
     mov             rax, SYS_WRITE


### PR DESCRIPTION
## Problem
`who` and `users` hardcoded `/var/run/utmp` and exited 1 with an error when it couldn't be opened. On modern Linux the canonical path is `/run/utmp` (`/var/run` is usually a symlink), and minimal containers/chroots may have neither — which is why the `who` smoke test failed in such environments:
```
not ok 71 who — lists users
# output : Error: Cannot open /var/run/utmp
```

## Change
For both utilities:
1. Try **`/run/utmp`** first, then fall back to **`/var/run/utmp`**.
2. When neither can be opened, treat it as **"no logged-in users"** — print nothing and exit `0`, matching coreutils — instead of erroring out. (Read errors on an opened file still report failure.)

## Verification
- Both build with `nasm -w+all` (no warnings); `make lint-format` clean.
- No utmp present (this environment): `who` → exit 0, no output (was exit 1 + error); `users` → exit 0.
- Empty `/run/utmp`: open-success path taken; `who` prints nothing, `users` prints the empty-list newline — confirming the fallback opens the file.
- Full bats suite: **`who` test now passes** (75 ok), no new failures. (The remaining chown/chgrp failures are the run-as-root assumption, addressed by #182.)

Closes #160

---
🤖 Generated with Claude Code — https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_