### PR TITLE
Fix utmp handling in users/who, preserve wide usernames, and make Bats tests portable

### DIFF
--- a/src/users.asm
+++ b/src/users.asm
@@ -16,27 +16,31 @@ section .text
 global      _start
 
 _start:
-    mov         rdi, default_utmp_path  ;Default path to the utmp file
     cmp         qword [rsp], 2
-    jl          open_utmp
+    jl          open_default_utmp
     mov         rdi, [rsp + 16]         ;Optional FILE argument
+    jmp         open_selected_utmp
 
-open_utmp:
-    mov         rax, SYS_OPEN
+open_default_utmp:
     mov         rdi, utmp_run           ;Try modern path first
-    mov         rsi, O_RDONLY
-    xor         rdx, rdx
-    syscall
+    call        try_open_utmp
     test        rax, rax
     jns         opened
 
-    mov         rax, SYS_OPEN
     mov         rdi, utmp_path          ;Fall back to legacy path
+
+open_selected_utmp:
+    call        try_open_utmp
+    test        rax, rax
+    js          no_utmp                 ;No utmp -> no logged-in users
+    jmp         opened
+
+try_open_utmp:
+    mov         rax, SYS_OPEN
     mov         rsi, O_RDONLY
     xor         rdx, rdx
     syscall
-    test        rax, rax
-    js          no_utmp                 ;No utmp -> no logged-in users
+    ret
 
 opened:
     mov         r15, rax
@@ -82,8 +86,11 @@ first_username:
     repne       scasb                   ;Scan for NULL (0)
     mov         rdx, UT_NAMESIZE
     sub         rdx, rcx
-    dec         rdx                     ;username length
+    test        rcx, rcx
+    jz          write_username          ;full-width username without NUL
+    dec         rdx                     ;exclude the NUL terminator
 
+write_username:
     mov         rax, SYS_WRITE
     mov         rdi, STDOUT_FILENO
     mov         rsi, username

--- a/src/who.asm
+++ b/src/who.asm
@@ -6,7 +6,8 @@ section .bss
     utmp_buf        resb UTMP_SIZE
 
 section .data
-    default_utmp_file db "/run/utmp", 0
+    utmp_run        db "/run/utmp", 0
+    utmp_file       db "/var/run/utmp", 0
 errmsg_open     db "who: cannot open utmp file", 10
     errmsg_open_len equ $ - errmsg_open
 errmsg_read     db "who: cannot read utmp file", 10
@@ -18,27 +19,31 @@ section .text
 global          _start
 
 _start:
-    mov             rdi, default_utmp_file
     cmp             qword [rsp], 2
-    jl              .open_utmp
+    jl              .open_default_utmp
     mov             rdi, [rsp + 16]     ;Optional FILE argument
+    jmp             .open_selected_utmp
 
-.open_utmp:
-    mov             rax, SYS_OPEN
+.open_default_utmp:
     mov             rdi, utmp_run       ;try modern path first
-    mov             rsi, O_RDONLY
-    mov             rdx, 0
-    syscall
+    call            .try_open_utmp
     cmp             rax, 0
     jge             .opened
 
-    mov             rax, SYS_OPEN
     mov             rdi, utmp_file      ;fall back to legacy path
+
+.open_selected_utmp:
+    call            .try_open_utmp
+    cmp             rax, 0
+    jl              .no_utmp            ;no utmp -> no logged-in users
+    jmp             .opened
+
+.try_open_utmp:
+    mov             rax, SYS_OPEN
     mov             rsi, O_RDONLY
     mov             rdx, 0
     syscall
-    cmp             rax, 0
-    jl              .no_utmp            ;no utmp -> no logged-in users
+    ret
 
 .opened:
     mov             r12, rax            ;file descriptor

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -1,6 +1,15 @@
 #!/usr/bin/env bats
-load 'test_helper/bats-support/load'
-load 'test_helper/bats-assert/load'
+if [ -e "${BATS_TEST_DIRNAME}/test_helper/bats-support/load.bash" ]; then
+  load 'test_helper/bats-support/load'
+else
+  bats_load_library bats-support
+fi
+
+if [ -e "${BATS_TEST_DIRNAME}/test_helper/bats-assert/load.bash" ]; then
+  load 'test_helper/bats-assert/load'
+else
+  bats_load_library bats-assert
+fi
 
 # Directory with Baloo binaries ------------------------------------------------
 setup()  { BIN="${BATS_TEST_DIRNAME}/../bin"; TMP=$(mktemp -d); }
@@ -314,14 +323,20 @@ PY
 }
 
 @test "m4 — expands simple macros" {
-  printf "define(`name',`Baloo')Hello, name\n" >"$TMP/input.m4"
+  cat >"$TMP/input.m4" <<'EOF'
+define(`name',`Baloo')Hello, name
+EOF
   run "$BIN/m4" "$TMP/input.m4"
   assert_success
   assert_output "Hello, Baloo"
 }
 
 @test "m4 — supports undefine and ifdef" {
-  printf "ifdef(`name',`yes',`no')\ndefine(`name',`Baloo')ifdef(`name',`yes',`no')\nundefine(`name')ifdef(`name',`yes',`no')\n" >"$TMP/input.m4"
+  cat >"$TMP/input.m4" <<'EOF'
+ifdef(`name',`yes',`no')
+define(`name',`Baloo')ifdef(`name',`yes',`no')
+undefine(`name')ifdef(`name',`yes',`no')
+EOF
   run "$BIN/m4" "$TMP/input.m4"
   assert_success
   assert_output $'no\nyes\nno'


### PR DESCRIPTION
### Motivation
- Ensure `users` and `who` honor an explicit utmp file argument and fall back reliably to standard system utmp locations when none is provided.
- Preserve usernames that occupy the full utmp username field even when not NUL-terminated.
- Make the test suite robust across environments by loading either vendored test helpers or installed `bats` libraries and fix test fixtures that suffered from shell quoting/substitution.

### Description
- Refactor `src/users.asm` to separate default vs selected utmp opening, add a shared `try_open_utmp` helper, and only fall back from `/run/utmp` to `/var/run/utmp` when necessary.
- Fix username length handling in `src/users.asm` to detect full-width usernames without a terminating NUL and avoid truncating them.
- Apply the same explicit-argument/open-fallback pattern to `src/who.asm` and add `utmp_run` / `utmp_file` data labels.
- Update `tests/test_all.bats` to conditionally load `test_helper` from the repository or fall back to installed `bats-support`/`bats-assert`, and replace fragile `printf` fixtures for `m4` tests with here-documents to avoid shell quoting issues.

### Testing
- Ran `make test` (Bats suite), which completed successfully with all tests passing.
- Ran `make lint-format` (the project formatter checks), which completed successfully.
- Ran `make all` to build binaries, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2231d92d448328bd05e904e1de8b3d)