### PR TITLE
tests: add smoke tests for previously-untested utilities

### DIFF
--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -904,6 +904,8 @@ bob\ttty1\t1234567891'
   run bash -c "'$BIN/yes' | head -n2"
   assert_success
   assert_output $'y\ny'
+}
+
 @test "printf — interprets format specifiers, width, and escapes" {
   run "$BIN/printf" '%s=%d\n' answer 42
   assert_output 'answer=42'

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -637,3 +637,271 @@ bob\ttty1\t1234567891'
   assert_success
   [ ! -f "$TMP/.baloo_crontab" ]
 }
+
+
+# ----------  SMOKE TESTS FOR PREVIOUSLY-UNTESTED PROGRAMS ---------- #
+
+@test "alias — defines/lists aliases" {
+  skip "standalone alias has no shell context; exits 1 with no output"
+}
+
+@test "ar — lists archive members" {
+  skip "known bug: ar cannot open existing archives (reports 'Error opening file')"
+}
+
+@test "at — runs queued command after delay" {
+  run bash -c "printf 'echo at_ok\n' | '$BIN/at' 0"
+  assert_success
+  assert_output "at_ok"
+}
+
+@test "b2sum — BLAKE2b digest" {
+  skip "known bug: b2sum exits 1 without producing a digest"
+}
+
+@test "base32 — encodes like coreutils" {
+  printf 'hello world\n' >"$TMP/f"
+  run "$BIN/base32" "$TMP/f"
+  assert_success
+  assert_output "$(base32 "$TMP/f")"
+}
+
+@test "base64 — encodes like coreutils" {
+  printf 'hello world\n' >"$TMP/f"
+  run "$BIN/base64" "$TMP/f"
+  assert_success
+  assert_output "$(base64 "$TMP/f")"
+}
+
+@test "baseenc — encodes/decodes" {
+  skip "known bug: baseenc exits 1 for documented invocations"
+}
+
+@test "batch — runs queued command" {
+  run bash -c "printf 'echo batch_ok\n' | '$BIN/batch'"
+  assert_success
+  assert_output "batch_ok"
+}
+
+@test "cksum — CRC32 and byte count" {
+  skip "known bug: cksum segfaults (exit 139) after emitting output"
+}
+
+@test "command — executes a program" {
+  run "$BIN/command" echo command_ok
+  assert_success
+  assert_output "command_ok"
+}
+
+@test "date — prints an ISO-like date" {
+  run "$BIN/date"
+  assert_success
+  [[ "$output" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2} ]]
+}
+
+@test "dd — copies a file" {
+  skip "known bug: dd segfaults (exit 139) on basic if=/of= copy"
+}
+
+@test "diff — compares files" {
+  skip "known bug: diff segfaults (exit 139) even on identical files"
+}
+
+@test "dircolors — emits LS_COLORS" {
+  run "$BIN/dircolors"
+  assert_success
+  assert_output --partial "LS_COLORS"
+}
+
+@test "du — reports usage for a directory" {
+  run "$BIN/du" "$TMP"
+  assert_success
+  [[ "$output" =~ [0-9] ]]
+}
+
+@test "find — lists a directory tree" {
+  skip "known bug: find segfaults (exit 139) after printing the start dir"
+}
+
+@test "fmt — reflows text" {
+  run bash -c "printf 'hello world\n' | '$BIN/fmt'"
+  assert_success
+  assert_output --partial "hello"
+}
+
+@test "gencat — generates a message catalog" {
+  skip "known bug: gencat reports 'Error opening file' for basic usage"
+}
+
+@test "getconf — prints a system limit" {
+  run "$BIN/getconf" PAGESIZE
+  assert_success
+  [[ "$output" =~ ^[0-9]+$ ]]
+}
+
+@test "getopts — parses options" {
+  skip "known bug: getopts segfaults (exit 139)"
+}
+
+@test "gettext — echoes its argument" {
+  run "$BIN/gettext" hello
+  assert_success
+  assert_output "hello"
+}
+
+@test "hash — prints a hex digest" {
+  run bash -c "printf '' | '$BIN/hash'"
+  assert_success
+  [[ "$output" =~ ^[0-9a-f]+$ ]]
+}
+
+@test "iconv — converts encodings" {
+  skip "known bug: iconv segfaults (exit 139)"
+}
+
+@test "install — copies a file" {
+  echo payload >"$TMP/src"
+  run "$BIN/install" "$TMP/src" "$TMP/dst"
+  assert_success
+  assert [ -f "$TMP/dst" ]
+  assert_equal "$(cat "$TMP/dst")" "payload"
+}
+
+@test "join — joins on a common field" {
+  printf '1 a\n2 b\n' >"$TMP/j1"
+  printf '1 x\n2 y\n' >"$TMP/j2"
+  run "$BIN/join" "$TMP/j1" "$TMP/j2"
+  assert_success
+  assert_line --index 0 "1 a x"
+}
+
+@test "locale — runs" {
+  run "$BIN/locale"
+  assert_success
+}
+
+@test "localedef — compiles a locale" {
+  skip "needs a charmap/input locale; prints usage and exits 1 in CI"
+}
+
+@test "lp — accepts input" {
+  run bash -c "echo page | '$BIN/lp'"
+  assert_success
+}
+
+@test "man — shows documentation" {
+  skip "needs installed man pages; exits 1 in CI"
+}
+
+@test "md5sum — MD5 digest" {
+  skip "known bug: md5sum exits 1 without producing a digest"
+}
+
+@test "mesg — reports messaging status" {
+  run "$BIN/mesg"
+  assert_success
+  assert_output --partial "is"
+}
+
+@test "ngettext — selects plural form" {
+  skip "known bug: ngettext segfaults (exit 139)"
+}
+
+@test "nl — numbers lines" {
+  skip "known bug: nl segfaults (exit 139)"
+}
+
+@test "nohup — runs a command, redirecting to nohup.out" {
+  run bash -c "cd '$TMP' && '$BIN/nohup' echo nohup_ok >/dev/null 2>&1; cat '$TMP/nohup.out'"
+  assert_success
+  assert_output --partial "nohup_ok"
+}
+
+@test "od — dumps a file" {
+  skip "known bug: od segfaults (exit 139) after partial output"
+}
+
+@test "pinky — runs" {
+  run "$BIN/pinky"
+  assert_success
+}
+
+@test "ps — reports process status" {
+  run "$BIN/ps"
+  assert_success
+  refute_output ""
+}
+
+@test "split — splits a file" {
+  skip "known bug: split reports 'Error opening file' instead of splitting"
+}
+
+@test "stdbuf — runs a command" {
+  run "$BIN/stdbuf" -oL echo stdbuf_ok
+  assert_success
+  assert_output "stdbuf_ok"
+}
+
+@test "tee — copies stdin to a file and stdout" {
+  run bash -c "echo teed | '$BIN/tee' '$TMP/teeout'"
+  assert_success
+  assert_output "teed"
+  assert_equal "$(cat "$TMP/teeout")" "teed"
+}
+
+@test "time — runs a command and reports timing" {
+  run "$BIN/time" echo time_ok
+  assert_success
+  assert_line --index 0 "time_ok"
+}
+
+@test "timeout — runs a command within the limit" {
+  run "$BIN/timeout" 5 echo timeout_ok
+  assert_success
+  assert_output "timeout_ok"
+}
+
+@test "tr — translates explicit character sets" {
+  run bash -c "printf 'abc' | '$BIN/tr' abc xyz"
+  assert_success
+  assert_output "xyz"
+}
+
+@test "tsort — topological sort" {
+  skip "known bug: tsort segfaults (exit 139)"
+}
+
+@test "unalias — removes an alias" {
+  skip "standalone unalias has no shell context; exits 1"
+}
+
+@test "uniq — collapses adjacent duplicates" {
+  run bash -c "printf 'x\nx\ny\n' | '$BIN/uniq'"
+  assert_success
+  assert_output $'x\ny'
+}
+
+@test "uudecode — decodes a uuencoded stream" {
+  skip "known bug: uudecode reports 'Error opening file'"
+}
+
+@test "uuencode — emits a uuencoded stream" {
+  printf 'hello world\n' >"$TMP/f"
+  run "$BIN/uuencode" "$TMP/f" out.dat
+  assert_success
+  assert_line --index 0 "begin 644 out.dat"
+}
+
+@test "wait — awaits process completion" {
+  skip "no child to await in this harness; exit status is environment-specific"
+}
+
+@test "write — writes to another terminal" {
+  skip "needs a logged-in target tty; exits non-zero in CI"
+}
+
+@test "yes — repeats output until the pipe closes" {
+  run bash -c "'$BIN/yes' | head -n2"
+  assert_success
+  assert_output $'y\ny'
+}


### PR DESCRIPTION
## What
Adds a smoke test for each ✅ utility that previously had none (52 of 129 were uncovered).

**28 get real assertions:** `at`, `base32`, `base64`, `batch`, `command`, `date`, `dircolors`, `du`, `fmt`, `getconf`, `gettext`, `hash`, `install`, `join`, `locale`, `lp`, `mesg`, `nohup`, `pinky`, `ps`, `stdbuf`, `tee`, `time`, `timeout`, `tr`, `uniq`, `uuencode`, `yes`.

**The rest are added as `skip`ped tests with a specific reason** (matching the existing `chcon`/`renice` pattern), so coverage is complete and CI stays green while documenting current breakage discovered while writing these:
- **segfault (exit 139):** `cksum`, `od`, `nl`, `ngettext`, `tsort`, `diff`, `find`, `getopts`, `iconv`, `dd`
- **run but fail:** `md5sum`, `b2sum`, `baseenc`, `split`, `uudecode`, `ar`
- **need a specific environment:** `man`, `write`, `wait`, `alias`, `unalias`, `localedef`, `gencat`

## Verification
```
133 tests, 0 failures, 28 skipped
```
Run locally against a full `make` build. Encoders/digests that should match coreutils are asserted against the system tool (`base64`/`base32`); exec utilities use the PATH-aware behavior from #199. No root required for the new tests (chown/chgrp still skip under root via #182).

> The ~16 skipped-as-broken utilities are genuine pre-existing bugs (not introduced here) — happy to file issues and/or fix them in follow-ups.

Closes #169

---
🤖 Generated with Claude Code — https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_