### PR TITLE
pathchk: implement file-name validation

### DIFF
--- a/Baloo.json
+++ b/Baloo.json
@@ -531,7 +531,7 @@
     "name": "pathchk",
     "description": "Checks whether file names are valid or portable",
     "glyph": "✓",
-    "isDone": false
+    "isDone": true
   },
   {
     "name": "pax",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baloo 🐻 
 
-![Progress](https://img.shields.io/badge/progress-129%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/Baloo.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-130%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/Baloo.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 
@@ -125,7 +125,7 @@ Commands:
 - [`od`](src/od.asm) ✅ Dumps files in octal and other formats
 - `paste` ⛔️ Merge corresponding or subsequent lines of files
 - `patch` ⛔️ Apply changes to files
-- `pathchk` ⛔️ Checks whether file names are valid or portable
+- [`pathchk`](src/pathchk.asm) ✅ Checks whether file names are valid or portable
 - `pax` ⛔️ Portable archive interchange
 - [`pinky`](src/pinky.asm) ✅ A lightweight version of finger
 - `pr` ⛔️ Paginate or columnate files for printing

--- a/src/pathchk.asm
+++ b/src/pathchk.asm
@@ -1,0 +1,73 @@
+; src/pathchk.asm -- check whether path names are valid.
+; Verifies each operand is non-empty, within PATH_MAX, and has no
+; component longer than NAME_MAX. Exits 0 when all operands are valid.
+
+    %include "include/sysdefs.inc"
+
+    %define PATH_MAX 4096
+    %define NAME_MAX 255
+
+section .data
+err_missing db "pathchk: missing operand", 10
+    err_missing_len equ $ - err_missing
+err_empty   db "pathchk: empty file name", 10
+    err_empty_len equ $ - err_empty
+err_long    db "pathchk: name too long", 10
+    err_long_len equ $ - err_long
+
+section .text
+global _start
+
+_start:
+    pop     r12                         ;argc
+    pop     rdi                         ;argv[0] discarded
+    cmp     r12, 1
+    jle     .missing
+    dec     r12                         ;operand count
+    mov     rbx, rsp                    ;&argv[1]
+.next_arg:
+    test    r12, r12
+    jz      .ok
+    mov     rsi, [rbx]
+    call    check_path
+    add     rbx, 8
+    dec     r12
+    jmp     .next_arg
+.ok:
+    exit    0
+
+.missing:
+    write   STDERR_FILENO, err_missing, err_missing_len
+    exit    1
+
+; check_path: validate the NUL-terminated path in rsi (exits 1 on failure)
+check_path:
+    cmp     byte [rsi], 0
+    je      .empty
+    xor     rcx, rcx                    ;total length
+    xor     rdx, rdx                    ;current component length
+.scan:
+    mov     al, [rsi + rcx]
+    test    al, al
+    jz      .done
+    cmp     al, '/'
+    je      .sep
+    inc     rdx
+    cmp     rdx, NAME_MAX
+    ja      .too_long
+    jmp     .advance
+.sep:
+    xor     rdx, rdx
+.advance:
+    inc     rcx
+    cmp     rcx, PATH_MAX
+    jae     .too_long
+    jmp     .scan
+.done:
+    ret
+.empty:
+    write   STDERR_FILENO, err_empty, err_empty_len
+    exit    1
+.too_long:
+    write   STDERR_FILENO, err_long, err_long_len
+    exit    1

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -918,3 +918,10 @@ bob\ttty1\t1234567891'
   run "$BIN/printf" '%s\n' a b c
   assert_output $'a\nb\nc'
 }
+
+@test "pathchk — accepts a valid name, rejects an empty one" {
+  run "$BIN/pathchk" "valid/path/name"
+  assert_success
+  run "$BIN/pathchk" ""
+  assert_failure
+}


### PR DESCRIPTION
## What
Implements **`pathchk`** — validates that each operand is non-empty, within `PATH_MAX` (4096), and has no component longer than `NAME_MAX` (255). Exits 0 when all operands are valid; non-zero with a diagnostic otherwise.

## Verification
Success/failure agreement with coreutils `pathchk` across: valid absolute/relative/nested names, an empty name, and an over-long (300-char) component — all 6 agree. `nasm -w+all` clean; lint + readme-links clean; smoke test added.

Part of #172.

---
🤖 Generated with Claude Code — https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_