### PR TITLE
realpath: implement canonical path resolution

### DIFF
--- a/Baloo.json
+++ b/Baloo.json
@@ -597,7 +597,7 @@
     "name": "realpath",
     "description": "Returns the resolved absolute or relative path for a file",
     "glyph": "🛣️",
-    "isDone": false
+    "isDone": true
   },
   {
     "name": "renice",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baloo 🐻 
 
-![Progress](https://img.shields.io/badge/progress-129%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/Baloo.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-130%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/Baloo.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 
@@ -136,7 +136,7 @@ Commands:
 - [`pwd`](src/pwd.asm) ✅ Prints the current working directory
 - `read` ⛔️ Read a line from standard input
 - [`readlink`](src/readlink.asm) ✅ Print destination of a symbolic link
-- `realpath` ⛔️ Returns the resolved absolute or relative path for a file
+- [`realpath`](src/realpath.asm) ✅ Returns the resolved absolute or relative path for a file
 - [`renice`](src/renice.asm) ✅ Set nice values of running processes
 - [`rm`](src/rm.asm) ✅ Removes files/directories
 - [`rmdir`](src/rmdir.asm) ✅ Removes empty directories

--- a/src/realpath.asm
+++ b/src/realpath.asm
@@ -1,0 +1,103 @@
+; src/realpath.asm -- print the canonical absolute path of an operand.
+; Resolves symlinks, "." and ".." by opening the path with O_PATH and
+; reading /proc/self/fd/N (the kernel's canonical name). The path must
+; exist (as with realpath -e).
+; Usage: realpath PATH
+
+    %include "include/sysdefs.inc"
+
+    %define O_PATH 0o10000000
+
+section .data
+    procprefix db "/proc/self/fd/"
+    procprefix_len equ $ - procprefix
+    newline db 10
+err_msg db "realpath: cannot resolve path", 10
+    err_len equ $ - err_msg
+
+section .bss
+    procpath resb 64
+    numtmp   resb 24
+    outbuf   resb 4096
+
+section .text
+global _start
+
+_start:
+    pop     rax                         ;argc
+    pop     rdi                         ;argv[0] discarded
+    cmp     rax, 2
+    jl      .fail
+    pop     rdi                         ;argv[1] = path
+
+    mov     rax, SYS_OPEN
+    mov     rsi, O_PATH
+    xor     rdx, rdx
+    syscall
+    test    rax, rax
+    js      .fail
+    mov     r12, rax                    ;fd
+
+    call    build_procpath
+
+    mov     rax, SYS_READLINK
+    mov     rdi, procpath
+    mov     rsi, outbuf
+    mov     rdx, 4096
+    syscall
+    test    rax, rax
+    jle     .fail
+
+    mov     rdx, rax                    ;length of canonical path
+    mov     rax, SYS_WRITE
+    mov     rdi, STDOUT_FILENO
+    mov     rsi, outbuf
+    syscall
+    write   STDOUT_FILENO, newline, 1
+    exit    0
+
+.fail:
+    write   STDERR_FILENO, err_msg, err_len
+    exit    1
+
+; build_procpath: write "/proc/self/fd/<r12>" (NUL-terminated) into procpath
+build_procpath:
+    mov     rsi, procprefix
+    mov     rdi, procpath
+    mov     rcx, procprefix_len
+.copy:
+    mov     al, [rsi]
+    mov     [rdi], al
+    inc     rsi
+    inc     rdi
+    dec     rcx
+    jnz     .copy
+    mov     rax, r12
+    test    rax, rax
+    jnz     .convert
+    mov     byte [rdi], '0'
+    inc     rdi
+    jmp     .term
+.convert:
+    lea     r8, [numtmp + 24]
+    mov     rbx, 10
+.digits:
+    xor     rdx, rdx
+    div     rbx
+    add     dl, '0'
+    dec     r8
+    mov     [r8], dl
+    test    rax, rax
+    jnz     .digits
+    lea     r9, [numtmp + 24]
+.emit:
+    cmp     r8, r9
+    jge     .term
+    mov     al, [r8]
+    mov     [rdi], al
+    inc     rdi
+    inc     r8
+    jmp     .emit
+.term:
+    mov     byte [rdi], 0
+    ret

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -918,3 +918,10 @@ bob\ttty1\t1234567891'
   run "$BIN/printf" '%s\n' a b c
   assert_output $'a\nb\nc'
 }
+
+@test "realpath — canonicalizes an existing path" {
+  mkdir -p "$TMP/d/sub"; touch "$TMP/d/sub/f"
+  run "$BIN/realpath" "$TMP/d/./sub/../sub/f"
+  assert_success
+  assert_output "$(realpath "$TMP/d/./sub/../sub/f")"
+}


### PR DESCRIPTION
## What
Implements **`realpath`** — prints the canonical absolute path of an operand, resolving symlinks, `.` and `..`. It does this by opening the path with `O_PATH` and reading `/proc/self/fd/N` (the kernel's canonical name). The path must exist (as with `realpath -e`).

## Verification
Byte-for-byte vs coreutils `realpath` for: absolute paths, paths containing `.`/`..`, a directory, a **symlink** (resolved to its target), and a relative path — all 6 match. `nasm -w+all` clean; lint + readme-links clean; smoke test added.

> Resolves existing paths (the core job — symlink/`.`/`..` canonicalization). The default GNU mode of tolerating a missing final component (`-m`-like) is a documented follow-up. Part of #172.

---
🤖 Generated with Claude Code — https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_