### PR TITLE
read: implement reading a line from standard input

### DIFF
--- a/Baloo.json
+++ b/Baloo.json
@@ -585,7 +585,7 @@
     "name": "read",
     "description": "Read a line from standard input",
     "glyph": "📖",
-    "isDone": false
+    "isDone": true
   },
   {
     "name": "readlink",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baloo 🐻 
 
-![Progress](https://img.shields.io/badge/progress-129%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/Baloo.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-130%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/Baloo.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 
@@ -134,7 +134,7 @@ Commands:
 - [`ps`](src/ps.asm) ✅ Report process status
 - `ptx` ⛔️ Produces a permuted index of file contents
 - [`pwd`](src/pwd.asm) ✅ Prints the current working directory
-- `read` ⛔️ Read a line from standard input
+- [`read`](src/read.asm) ✅ Read a line from standard input
 - [`readlink`](src/readlink.asm) ✅ Print destination of a symbolic link
 - `realpath` ⛔️ Returns the resolved absolute or relative path for a file
 - [`renice`](src/renice.asm) ✅ Set nice values of running processes

--- a/src/read.asm
+++ b/src/read.asm
@@ -1,0 +1,44 @@
+; src/read.asm -- read a single line from standard input and echo it.
+; Reads one byte at a time so no input past the line is consumed (as a
+; shell `read` would behave). Exits 0 once a line is read, 1 on EOF with
+; no data.
+
+    %include "include/sysdefs.inc"
+
+    %define LINEBUF_SIZE 65536
+
+section .bss
+    linebuf resb LINEBUF_SIZE + 1
+
+section .text
+global _start
+
+_start:
+    xor     r12, r12                    ;bytes in the line so far
+.read_byte:
+    mov     rax, SYS_READ
+    xor     rdi, rdi                    ;stdin
+    lea     rsi, [linebuf + r12]
+    mov     rdx, 1
+    syscall
+    cmp     rax, 1
+    jne     .eof
+    mov     al, [linebuf + r12]
+    cmp     al, 10                      ;end of line
+    je      .emit
+    inc     r12
+    cmp     r12, LINEBUF_SIZE
+    jb      .read_byte
+.emit:
+    mov     byte [linebuf + r12], 10    ;newline-terminate the echoed line
+    inc     r12
+    mov     rax, SYS_WRITE
+    mov     rdi, STDOUT_FILENO
+    mov     rsi, linebuf
+    mov     rdx, r12
+    syscall
+    exit    0
+.eof:
+    test    r12, r12
+    jnz     .emit                       ;final line without a trailing newline
+    exit    1

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -918,3 +918,9 @@ bob\ttty1\t1234567891'
   run "$BIN/printf" '%s\n' a b c
   assert_output $'a\nb\nc'
 }
+
+@test "read — echoes the first line of input" {
+  run bash -c "printf 'first\nsecond\n' | '$BIN/read'"
+  assert_success
+  assert_output "first"
+}


### PR DESCRIPTION
## What
Implements **`read`** — reads a single line from standard input (one byte at a time, so no input past the line is consumed, like a shell `read`) and echoes it, newline-terminated. Exits 0 once a line is read (including a final line with no trailing newline) and 1 on EOF with no data.

## Verification
4/4 behavior checks: echoes the first line and stops, handles a line without a trailing newline, an empty line, and immediate EOF (exit 1). `nasm -w+all` clean; lint + readme-links clean; smoke test added.

> `read` is normally a shell built-in with no coreutils binary, so this provides a sensible stand-alone line reader matching the catalog description. Part of #172.

---
🤖 Generated with Claude Code — https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_