### PR TITLE
Add README update check to CI

### DIFF
--- a/.github/workflows/Baloo.yml
+++ b/.github/workflows/Baloo.yml
@@ -29,6 +29,9 @@ jobs:
     - name: Compile      
       run: make
 
+    - name: Verify README is up to date
+      run: make check-readme
+
     - name: Verify README catalog links
       run: make check-readme-links
 

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,10 @@ BIN := $(patsubst src/%.asm,bin/%,$(SRC))
 
 FMT_FILES := $(SRC) $(INC)
 FMT_SCRIPT := scripts/asmfmt.py
+README_SCRIPT := scripts/update_readme.py
 TEST_FLAGS ?= --timing
 
-.PHONY: all setup clean test format lint-format check-readme-links
+.PHONY: all setup clean test format lint-format update-readme check-readme check-readme-links
 
 .SECONDARY: $(OBJ)
 
@@ -27,9 +28,15 @@ bin/%: build/%.o
 format:
 	python3 $(FMT_SCRIPT) $(FMT_FILES)
 
+update-readme:
+	python3 $(README_SCRIPT)
+
+check-readme: update-readme
+	git diff --exit-code README.md
+
 lint-format:
 	python3 $(FMT_SCRIPT) --check $(FMT_FILES)
-	python3 -m compileall -q scripts/asmfmt.py
+	python3 -m compileall -q scripts/asmfmt.py $(README_SCRIPT)
 
 test: all
 	bats $(TEST_FLAGS) tests/test_all.bats

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -57,7 +57,7 @@ def main() -> None:
 
     catalog_lines = [catalog_entry_line(entry, src_dir) for entry in data]
 
-    lines[start:end] = catalog_lines
+    lines[start:end] = catalog_lines + [""]
     readme_path.write_text("\n".join(lines) + "\n")
 
 


### PR DESCRIPTION
### Motivation
- Ensure the repository README is kept in sync with the canonical `Baloo.json` catalog by verifying generated README content in CI.
- Make the README generator part of the normal tooling so drift is detected early in PRs.

### Description
- Add a CI step in `.github/workflows/Baloo.yml` that runs `make check-readme` after compilation to verify README is up to date.
- Add `README_SCRIPT := scripts/update_readme.py`, an `update-readme` target that runs the generator, and a `check-readme` target that runs `update-readme` and fails on any `README.md` diff in `Makefile`.
- Update `scripts/update_readme.py` to preserve the blank line before the `## Benchmark` section so the generator is idempotent with the current README formatting.
- Include `scripts/update_readme.py` in the byte-compilation check invoked by `make lint-format`.

### Testing
- Ran `make check-readme` which executes `python3 scripts/update_readme.py` and `git diff --exit-code README.md`, and it completed successfully.
- Ran `make check-readme-links` which runs `python3 scripts/check_readme_links.py`, and it reported valid links.
- Ran `make lint-format` which runs the formatter check and byte-compiles scripts, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22f3247e548328a0b5a03423c6abdc)