### PR TITLE
Implement runcon

### DIFF
--- a/Baloo.json
+++ b/Baloo.json
@@ -621,7 +621,7 @@
     "name": "runcon",
     "description": "Run command with specified security context",
     "glyph": "🔓",
-    "isDone": false
+    "isDone": true
   },
   {
     "name": "sed",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baloo 🐻 
 
-![Progress](https://img.shields.io/badge/progress-129%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/Baloo.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-130%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/Baloo.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 
@@ -140,7 +140,7 @@ Commands:
 - [`renice`](src/renice.asm) ✅ Set nice values of running processes
 - [`rm`](src/rm.asm) ✅ Removes files/directories
 - [`rmdir`](src/rmdir.asm) ✅ Removes empty directories
-- `runcon` ⛔️ Run command with specified security context
+- [`runcon`](src/runcon.asm) ✅ Run command with specified security context
 - `sed` ⛔️ Stream editor
 - [`seq`](src/seq.asm) ✅ Prints a sequence of numbers
 - `sh` ⛔️ Shell, the standard command language interpreter

--- a/src/runcon.asm
+++ b/src/runcon.asm
@@ -1,0 +1,179 @@
+; src/runcon.asm
+;
+; runcon - run a command in a specified SELinux security context.
+;
+; Supported forms
+;   runcon                     print the current security context
+;   runcon CONTEXT COMMAND...  run COMMAND in the given SELinux context
+;
+; With no arguments the current context is read from
+; /proc/self/attr/current and printed (coreutils prints "kernel" on a
+; kernel without SELinux enabled).  When a CONTEXT and a COMMAND are given,
+; the kernel must have SELinux enabled; CONTEXT is written to
+; /proc/self/attr/exec and the command is exec'd, matching
+; setexeccon(3) + execvp(3).
+;
+; Option flags (-u -r -t -l -c) are not parsed; this implements the plain
+; positional "CONTEXT COMMAND" form documented above.
+
+    %include "include/sysdefs.inc"
+
+    %define SELINUX_MAGIC 0xf97cff8c
+
+section .bss
+    ctx_buf      resb 4096
+    statfs_buf   resb 128
+
+section .data
+    attr_current db "/proc/self/attr/current", 0
+    attr_exec    db "/proc/self/attr/exec", 0
+    selinux_mnt  db "/sys/fs/selinux", 0
+no_cmd_msg   db "runcon: no command specified", 10, "Try 'runcon --help' for more information.", 10
+    no_cmd_len   equ $ - no_cmd_msg
+sel_msg      db "runcon: runcon may be used only on a SELinux kernel", 10
+    sel_len      equ $ - sel_msg
+set_err_msg  db "runcon: failed to set execution context", 10
+    set_err_len  equ $ - set_err_msg
+read_err_msg db "runcon: failed to get current context", 10
+    read_err_len equ $ - read_err_msg
+run_err_msg  db "runcon: cannot run command", 10
+    run_err_len  equ $ - run_err_msg
+    newline      db 10
+
+section .text
+global _start
+
+_start:
+    pop     rbx                         ;argc
+    mov     r12, rsp                    ;argv pointer
+    lea     r13, [r12 + rbx*8 + 8]      ;envp pointer
+
+    cmp     rbx, 1
+    je      print_current               ;no args, print current context
+    cmp     rbx, 2
+    jle     no_command                  ;context given but no command
+
+;------------------------------------------------------------------
+; runcon CONTEXT COMMAND [ARGS...]
+; argv[1] = context, argv[2..] = command and its arguments
+;------------------------------------------------------------------
+run_with_context:
+    call    is_selinux_enabled
+    test    rax, rax
+    jz      not_selinux
+
+    mov     r14, [r12 + 8]              ;context string
+
+    mov     rax, SYS_OPEN               ;open attr/exec for writing
+    mov     rdi, attr_exec
+    mov     rsi, O_WRONLY
+    xor     rdx, rdx
+    syscall
+    cmp     rax, 0
+    jl      set_failed
+    mov     r15, rax                    ;fd
+
+    mov     rsi, r14                    ;measure context length
+    call    strlen                      ;rbx = length without NUL
+    inc     rbx                         ;libselinux writes the NUL too
+
+    mov     rax, SYS_WRITE
+    mov     rdi, r15
+    mov     rsi, r14
+    mov     rdx, rbx
+    syscall
+    mov     rbx, rax                    ;save write result
+
+    mov     rax, SYS_CLOSE
+    mov     rdi, r15
+    syscall
+
+    cmp     rbx, 0
+    jl      set_failed
+
+    lea     rsi, [r12 + 16]             ;&argv[2] becomes the new argv
+    mov     rdi, [rsi]                  ;command name
+    mov     rdx, r13                    ;envp
+    call    __path_execve
+
+    write   STDERR_FILENO, run_err_msg, run_err_len
+    exit    126
+
+;------------------------------------------------------------------
+print_current:
+    mov     rax, SYS_OPEN
+    mov     rdi, attr_current
+    mov     rsi, O_RDONLY
+    xor     rdx, rdx
+    syscall
+    cmp     rax, 0
+    jl      read_failed
+    mov     r15, rax                    ;fd
+
+    mov     rax, SYS_READ
+    mov     rdi, r15
+    mov     rsi, ctx_buf
+    mov     rdx, 4096
+    syscall
+    mov     r14, rax                    ;bytes read
+
+    mov     rax, SYS_CLOSE
+    mov     rdi, r15
+    syscall
+
+    cmp     r14, 0
+    jl      read_failed
+
+    xor     rcx, rcx                    ;trim at first NUL or newline
+.scan:
+    cmp     rcx, r14
+    jge     .emit
+    mov     al, [ctx_buf + rcx]
+    test    al, al
+    je      .emit
+    cmp     al, 10
+    je      .emit
+    inc     rcx
+    jmp     .scan
+
+.emit:
+    write   STDOUT_FILENO, ctx_buf, rcx
+    write   STDOUT_FILENO, newline, 1
+    exit    0
+
+;------------------------------------------------------------------
+; is_selinux_enabled returns rax = 1 when selinuxfs is mounted at
+; /sys/fs/selinux, else 0.  Mirrors libselinux's mountpoint check.
+;------------------------------------------------------------------
+is_selinux_enabled:
+    mov     rax, SYS_STATFS
+    mov     rdi, selinux_mnt
+    mov     rsi, statfs_buf
+    syscall
+    test    rax, rax
+    js      .no
+    mov     eax, dword [statfs_buf]     ;f_type, low 32 bits
+    cmp     eax, SELINUX_MAGIC
+    jne     .no
+    mov     rax, 1
+    ret
+.no:
+    xor     rax, rax
+    ret
+
+;------------------------------------------------------------------
+no_command:
+    write   STDERR_FILENO, no_cmd_msg, no_cmd_len
+    exit    125
+
+not_selinux:
+    write   STDERR_FILENO, sel_msg, sel_len
+    exit    125
+
+set_failed:
+    write   STDERR_FILENO, set_err_msg, set_err_len
+    exit    125
+
+read_failed:
+    write   STDERR_FILENO, read_err_msg, read_err_len
+    exit    1

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -918,3 +918,29 @@ bob\ttty1\t1234567891'
   run "$BIN/printf" '%s\n' a b c
   assert_output $'a\nb\nc'
 }
+
+@test "runcon — prints the current security context" {
+  # With no arguments runcon prints the process's context from
+  # /proc/self/attr/current ("kernel" on a kernel without SELinux).
+  [ -r /proc/self/attr/current ] || skip "no /proc/self/attr/current here"
+  expected=$(tr -d '\000' < /proc/self/attr/current)
+  run "$BIN/runcon"
+  assert_success
+  assert_output "$expected"
+}
+
+@test "runcon — rejects a context with no command" {
+  run "$BIN/runcon" foo
+  assert_failure 125
+  assert_output --partial "no command specified"
+}
+
+@test "runcon — refuses to run a command off a SELinux kernel" {
+  # statfs magic of a mounted selinuxfs; skip where SELinux is enabled.
+  if [ "$(stat -f -c '%t' /sys/fs/selinux 2>/dev/null)" = "f97cff8c" ]; then
+    skip "SELinux is enabled; the guard path is not exercised"
+  fi
+  run "$BIN/runcon" foo /bin/echo hi
+  assert_failure 125
+  assert_output --partial "SELinux kernel"
+}


### PR DESCRIPTION
## Summary

Implements `runcon` in pure x86_64 assembly — run a command in a specified SELinux security context. Covers coreutils' positional `CONTEXT COMMAND` form plus the no-argument context print.

## Behavior

| Invocation | Action | Exit |
|---|---|---|
| `runcon` | Read `/proc/self/attr/current` and print the current context (`kernel` on a non-SELinux kernel) | 0 |
| `runcon CONTEXT` | `runcon: no command specified` + try-help hint | 125 |
| `runcon CONTEXT COMMAND...` (no SELinux) | `runcon: runcon may be used only on a SELinux kernel` | 125 |
| `runcon CONTEXT COMMAND...` (SELinux) | Write `CONTEXT` to `/proc/self/attr/exec`, then exec the command via the shared PATH helper | exec |

SELinux availability is detected with a single `statfs(2)` on `/sys/fs/selinux`, checking `f_type == SELINUX_MAGIC` (mirrors libselinux's mountpoint check). The command is exec'd through `__path_execve`, so PATH lookup matches the other exec-family utilities.

## Verification

All three environment-reachable cases match coreutils **byte-for-byte** on stdout, stderr, and exit status (verified against the system `runcon`). Option flags (`-u -r -t -l -c`) are intentionally out of scope; this implements the documented positional form.

## Notes

- Flips the `Baloo.json` catalog entry to done and regenerates the README catalog/progress badge.
- Adds three smoke tests: the no-arg context print (self-contained against `/proc/self/attr/current`), the no-command rejection, and the SELinux guard (auto-skipped where SELinux is enabled).
- All 130 binaries build; `asmfmt --check` and README link checks pass.

https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_