### PR TITLE
Implement tput

### DIFF
--- a/Baloo.json
+++ b/Baloo.json
@@ -789,7 +789,7 @@
     "name": "tput",
     "description": "Change terminal characteristics",
     "glyph": "🎮",
-    "isDone": false
+    "isDone": true
   },
   {
     "name": "tr",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baloo 🐻 
 
-![Progress](https://img.shields.io/badge/progress-143%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/Baloo.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-144%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/Baloo.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 
@@ -168,7 +168,7 @@ Commands:
 - [`time`](src/time.asm) ✅ Display elapsed, system and kernel time
 - [`timeout`](src/timeout.asm) ✅ Runs a command with a time limit
 - [`touch`](src/touch.asm) ✅ Changes file timestamps; creates file
-- `tput` ⛔️ Change terminal characteristics
+- [`tput`](src/tput.asm) ✅ Change terminal characteristics
 - [`tr`](src/tr.asm) ✅ Translates or deletes characters
 - [`true`](src/true.asm) ✅ Does nothing, but exits successfully
 - [`truncate`](src/truncate.asm) ✅ Shrink the size of a file to the specified size

--- a/src/tput.asm
+++ b/src/tput.asm
@@ -1,0 +1,422 @@
+; src/tput.asm
+;
+; tput - query terminal capabilities.
+;
+; Supported capabilities
+;   tput cols     number of columns
+;   tput lines    number of rows
+;
+; The value is resolved the way ncurses does, in this precedence order
+; (after validating $TERM):
+;   1. the COLUMNS / LINES environment variable, when set to a positive
+;      integer
+;   2. the live window size from TIOCGWINSZ on standard output, when it is
+;      a terminal reporting a non-zero size
+;   3. the static numeric capability from the terminfo database entry for
+;      $TERM, falling back to 80 columns / 24 lines
+;
+; The terminfo entry is parsed directly from the compiled database (both
+; the legacy 16-bit and the 32-bit number formats are understood). Other
+; capabilities and the parameterized string operations are out of scope.
+
+    %include "include/sysdefs.inc"
+
+    %define TIOCGWINSZ 0x5413
+    %define TI_MAGIC16 0x011A
+    %define TI_MAGIC32 0x021E
+
+section .bss
+    ti_buf      resb 8192               ;compiled terminfo entry
+    pathbuf     resb 4096               ;assembled database path
+    winsz       resw 4                  ;struct winsize
+    numbuf      resb 32                 ;decimal conversion scratch
+    cap_ptr     resq 1                  ;requested capability name
+    term_ptr    resq 1                  ;value of $TERM
+    envp_ptr    resq 1                  ;environment pointer
+    ti_cols     resq 1                  ;terminfo columns, or -1 when absent
+    ti_lines    resq 1                  ;terminfo lines, or -1 when absent
+
+section .data
+    term_prefix     db "TERM=", 0
+    columns_prefix  db "COLUMNS=", 0
+    lines_prefix    db "LINES=", 0
+    terminfo_prefix db "TERMINFO=", 0
+    cap_cols        db "cols", 0
+    cap_lines       db "lines", 0
+    dir_etc         db "/etc/terminfo", 0
+    dir_usr         db "/usr/share/terminfo", 0
+    dir_lib         db "/lib/terminfo", 0
+usage_msg       db "Usage: tput [options] [command]", 10
+    usage_len       equ $ - usage_msg
+noterm_msg      db "tput: No value for $TERM and no -T specified", 10
+    noterm_len      equ $ - noterm_msg
+err_unk_pre     db 'tput: unknown terminal "'
+    err_unk_pre_len equ $ - err_unk_pre
+    err_unk_post    db '"', 10
+    err_unk_post_len equ $ - err_unk_post
+err_cap_pre     db "tput: unknown terminfo capability '"
+    err_cap_pre_len equ $ - err_cap_pre
+    err_cap_post    db "'", 10
+    err_cap_post_len equ $ - err_cap_post
+
+section .text
+global _start
+
+_start:
+    pop     rbx                         ;argc
+    mov     r12, rsp                    ;argv pointer
+    lea     r13, [r12 + rbx*8 + 8]      ;envp pointer
+    mov     [envp_ptr], r13
+
+    cmp     rbx, 2
+    jl      no_args                     ;tput with no capability
+
+    mov     rax, [r12 + 8]
+    mov     [cap_ptr], rax              ;argv[1] is the capability name
+
+; validate $TERM before anything else, matching setupterm
+    mov     rdi, term_prefix
+    mov     rsi, r13
+    call    __find_env
+    test    rax, rax
+    jz      no_term
+    mov     [term_ptr], rax
+
+    call    open_terminfo               ;exits via unknown_terminal on failure
+    call    parse_terminfo              ;fills ti_cols and ti_lines
+
+    mov     rdi, [cap_ptr]
+    mov     rsi, cap_cols
+    call    streq
+    test    rax, rax
+    jnz     do_cols
+
+    mov     rdi, [cap_ptr]
+    mov     rsi, cap_lines
+    call    streq
+    test    rax, rax
+    jnz     do_lines
+
+    jmp     unknown_cap
+
+;------------------------------------------------------------------
+do_cols:
+    mov     rdi, columns_prefix         ;COLUMNS overrides everything
+    mov     rsi, [envp_ptr]
+    call    __find_env
+    test    rax, rax
+    jz      .ioctl
+    mov     rsi, rax
+    call    parse_posint
+    cmp     rax, 0
+    jg      emit_value
+.ioctl:
+    call    get_winsize
+    test    rax, rax
+    jz      .ti
+    movzx   rax, word [winsz + 2]       ;ws_col
+    test    rax, rax
+    jnz     emit_value
+.ti:
+    mov     rax, [ti_cols]
+    test    rax, rax
+    jns     emit_value
+    mov     rax, 80
+    jmp     emit_value
+
+;------------------------------------------------------------------
+do_lines:
+    mov     rdi, lines_prefix           ;LINES overrides everything
+    mov     rsi, [envp_ptr]
+    call    __find_env
+    test    rax, rax
+    jz      .ioctl
+    mov     rsi, rax
+    call    parse_posint
+    cmp     rax, 0
+    jg      emit_value
+.ioctl:
+    call    get_winsize
+    test    rax, rax
+    jz      .ti
+    movzx   rax, word [winsz]           ;ws_row
+    test    rax, rax
+    jnz     emit_value
+.ti:
+    mov     rax, [ti_lines]
+    test    rax, rax
+    jns     emit_value
+    mov     rax, 24
+    jmp     emit_value
+
+;------------------------------------------------------------------
+; emit_value - print rax as unsigned decimal plus newline, then exit 0
+;------------------------------------------------------------------
+emit_value:
+    mov     rcx, numbuf + 31
+    mov     byte [rcx], 10              ;trailing newline
+    mov     rbx, 10
+.div:
+    xor     rdx, rdx
+    div     rbx
+    add     dl, '0'
+    dec     rcx
+    mov     [rcx], dl
+    test    rax, rax
+    jnz     .div
+
+    mov     rdx, numbuf + 32
+    sub     rdx, rcx                    ;digits plus newline
+    mov     rsi, rcx
+    mov     rdi, STDOUT_FILENO
+    mov     rax, SYS_WRITE
+    syscall
+    exit    0
+
+;------------------------------------------------------------------
+; open_terminfo - locate and read the terminfo entry for $TERM into
+; ti_buf. Tries $TERMINFO, then the standard system directories. Jumps to
+; unknown_terminal when no entry is found.
+;------------------------------------------------------------------
+open_terminfo:
+    mov     rdi, terminfo_prefix        ;honour $TERMINFO first
+    mov     rsi, [envp_ptr]
+    call    __find_env
+    test    rax, rax
+    jz      .try_etc
+    mov     rsi, rax
+    call    build_open
+    test    rax, rax
+    jns     .ok
+.try_etc:
+    mov     rsi, dir_etc
+    call    build_open
+    test    rax, rax
+    jns     .ok
+    mov     rsi, dir_usr
+    call    build_open
+    test    rax, rax
+    jns     .ok
+    mov     rsi, dir_lib
+    call    build_open
+    test    rax, rax
+    jns     .ok
+    jmp     unknown_terminal
+.ok:
+    mov     r10, rax                    ;file descriptor
+    mov     rax, SYS_READ
+    mov     rdi, r10
+    mov     rsi, ti_buf
+    mov     rdx, 8192
+    syscall
+    mov     r9, rax                     ;bytes read
+    mov     rax, SYS_CLOSE
+    mov     rdi, r10
+    syscall
+    mov     rax, r9
+    ret
+
+;------------------------------------------------------------------
+; build_open - assemble "<dir>/<c>/<TERM>" in pathbuf and open it.
+;   rsi = directory string. Returns rax = fd or negative errno.
+;------------------------------------------------------------------
+build_open:
+    mov     rdi, pathbuf
+    call    appendz                     ;directory
+    mov     byte [rdi], '/'
+    inc     rdi
+    mov     r8, [term_ptr]
+    mov     al, [r8]                    ;first character of $TERM
+    mov     [rdi], al
+    inc     rdi
+    mov     byte [rdi], '/'
+    inc     rdi
+    mov     rsi, [term_ptr]
+    call    appendz                     ;full terminal name
+    mov     byte [rdi], 0
+
+    mov     rax, SYS_OPEN
+    mov     rdi, pathbuf
+    mov     rsi, O_RDONLY
+    xor     rdx, rdx
+    syscall
+    ret
+
+;------------------------------------------------------------------
+; appendz - copy NUL-terminated string at rsi to rdi (no NUL), leaving
+; rdi just past the last byte written.
+;------------------------------------------------------------------
+appendz:
+    mov     al, [rsi]
+    test    al, al
+    jz      .done
+    mov     [rdi], al
+    inc     rdi
+    inc     rsi
+    jmp     appendz
+.done:
+    ret
+
+;------------------------------------------------------------------
+; parse_terminfo - read columns (number 0) and lines (number 2) from the
+; entry in ti_buf, storing them in ti_cols / ti_lines (-1 when absent).
+;------------------------------------------------------------------
+parse_terminfo:
+    movzx   rax, word [ti_buf]
+    cmp     ax, TI_MAGIC16
+    je      .m16
+    cmp     ax, TI_MAGIC32
+    je      .m32
+    jmp     unknown_terminal            ;unrecognised format
+
+.m16:
+    movzx   rcx, word [ti_buf + 2]      ;names size
+    movzx   rdx, word [ti_buf + 4]      ;bool count
+    movzx   r8, word [ti_buf + 6]       ;number count
+    lea     r9, [rcx + rdx + 12]
+    test    r9, 1
+    jz      .a16
+    inc     r9                          ;align to an even offset
+.a16:
+    cmp     r8, 1
+    jb      .no_cols16
+    movzx   rax, word [ti_buf + r9]
+    cmp     ax, 0xFFFE
+    jae     .no_cols16
+    mov     [ti_cols], rax
+    jmp     .lines16
+.no_cols16:
+    mov     qword [ti_cols], -1
+.lines16:
+    cmp     r8, 3
+    jb      .no_lines16
+    movzx   rax, word [ti_buf + r9 + 4]
+    cmp     ax, 0xFFFE
+    jae     .no_lines16
+    mov     [ti_lines], rax
+    ret
+.no_lines16:
+    mov     qword [ti_lines], -1
+    ret
+
+.m32:
+    movzx   rcx, word [ti_buf + 2]
+    movzx   rdx, word [ti_buf + 4]
+    movzx   r8, word [ti_buf + 6]
+    lea     r9, [rcx + rdx + 12]
+    test    r9, 1
+    jz      .a32
+    inc     r9
+.a32:
+    cmp     r8, 1
+    jb      .no_cols32
+    mov     eax, dword [ti_buf + r9]
+    cmp     eax, 0xFFFFFFFE
+    jae     .no_cols32
+    mov     [ti_cols], rax
+    jmp     .lines32
+.no_cols32:
+    mov     qword [ti_cols], -1
+.lines32:
+    cmp     r8, 3
+    jb      .no_lines32
+    mov     eax, dword [ti_buf + r9 + 8]
+    cmp     eax, 0xFFFFFFFE
+    jae     .no_lines32
+    mov     [ti_lines], rax
+    ret
+.no_lines32:
+    mov     qword [ti_lines], -1
+    ret
+
+;------------------------------------------------------------------
+; get_winsize - TIOCGWINSZ on standard output. rax = 1 on success, else 0.
+;------------------------------------------------------------------
+get_winsize:
+    mov     rax, SYS_IOCTL
+    mov     rdi, STDOUT_FILENO
+    mov     rsi, TIOCGWINSZ
+    mov     rdx, winsz
+    syscall
+    test    rax, rax
+    js      .fail
+    mov     rax, 1
+    ret
+.fail:
+    xor     rax, rax
+    ret
+
+;------------------------------------------------------------------
+; parse_posint - parse decimal digits at rsi. rax = value when the whole
+; string is digits and the value is positive, otherwise -1.
+;------------------------------------------------------------------
+parse_posint:
+    xor     rax, rax
+    xor     rcx, rcx
+.loop:
+    movzx   rdx, byte [rsi]
+    test    dl, dl
+    jz      .done
+    sub     dl, '0'
+    cmp     dl, 9
+    ja      .invalid
+    imul    rax, rax, 10
+    add     rax, rdx
+    inc     rsi
+    inc     rcx
+    jmp     .loop
+.done:
+    test    rcx, rcx
+    jz      .invalid
+    test    rax, rax
+    jz      .invalid
+    ret
+.invalid:
+    mov     rax, -1
+    ret
+
+;------------------------------------------------------------------
+; streq - compare two NUL-terminated strings, rax = 1 when equal
+;------------------------------------------------------------------
+streq:
+    xor     rcx, rcx
+.loop:
+    mov     al, [rdi + rcx]
+    mov     dl, [rsi + rcx]
+    cmp     al, dl
+    jne     .ne
+    test    al, al
+    je      .eq
+    inc     rcx
+    jmp     .loop
+.eq:
+    mov     rax, 1
+    ret
+.ne:
+    xor     rax, rax
+    ret
+
+;------------------------------------------------------------------
+no_args:
+    write   STDERR_FILENO, usage_msg, usage_len
+    exit    2
+
+no_term:
+    write   STDERR_FILENO, noterm_msg, noterm_len
+    exit    2
+
+unknown_terminal:
+    write   STDERR_FILENO, err_unk_pre, err_unk_pre_len
+    mov     rsi, [term_ptr]
+    call    strlen
+    write   STDERR_FILENO, rsi, rbx
+    write   STDERR_FILENO, err_unk_post, err_unk_post_len
+    exit    3
+
+unknown_cap:
+    write   STDERR_FILENO, err_cap_pre, err_cap_pre_len
+    mov     rsi, [cap_ptr]
+    call    strlen
+    write   STDERR_FILENO, rsi, rbx
+    write   STDERR_FILENO, err_cap_post, err_cap_post_len
+    exit    4

--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -523,6 +523,41 @@ EOF
   assert_failure
 }
 
+@test "tput - cols/lines fall back to the terminfo entry off a terminal" {
+  [ -e /usr/share/terminfo/x/xterm ] || skip "no xterm terminfo entry installed"
+  run env -u COLUMNS TERM=xterm "$BIN/tput" cols </dev/null
+  assert_success
+  assert_output "80"
+  run env -u LINES TERM=xterm "$BIN/tput" lines </dev/null
+  assert_success
+  assert_output "24"
+}
+
+@test "tput - reads the live size from a terminal" {
+  command -v python3 >/dev/null 2>&1 || skip "python3 needed to allocate a pty"
+  run python3 -c '
+import sys, os, pty, fcntl, termios, struct, subprocess, time
+m, s = pty.openpty()
+fcntl.ioctl(s, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 123, 0, 0))
+subprocess.run([sys.argv[1], "cols"], stdout=s, stdin=subprocess.DEVNULL, env={"TERM": "xterm"})
+os.set_blocking(m, False); time.sleep(0.05)
+sys.stdout.write(os.read(m, 50).decode().strip())
+' "$BIN/tput"
+  assert_output "123"
+}
+
+@test "tput - diagnoses an unknown terminal" {
+  run env -u TERMINFO TERM=definitely_not_a_terminal "$BIN/tput" cols </dev/null
+  assert_failure 3
+  assert_output --partial "unknown terminal"
+}
+
+@test "tput - rejects an unsupported capability" {
+  run env TERM=xterm "$BIN/tput" no_such_cap </dev/null
+  assert_failure 4
+  assert_output --partial "unknown terminfo capability"
+}
+
 @test "umask — prints current mask" {
   run "$BIN/umask"
   assert_success


### PR DESCRIPTION
## Summary

Implements `tput` in pure x86_64 assembly, supporting the `cols` and `lines` capabilities — the terminal width and height, which are by far the most commonly scripted tput queries.

## Value resolution

After validating `$TERM`, the value is resolved exactly the way ncurses does, in this precedence order:

1. the `COLUMNS` / `LINES` environment variable, when set to a positive integer;
2. otherwise the live window size from `TIOCGWINSZ` on **standard output**, when it is a terminal reporting a non-zero size;
3. otherwise the static numeric capability parsed straight from the compiled terminfo entry for `$TERM`, defaulting to 80 columns / 24 lines.

The terminfo entry is parsed directly from the compiled database — both the legacy 16-bit and the 32-bit number formats — searching `$TERMINFO` and the standard system directories (`/etc/terminfo`, `/usr/share/terminfo`, `/lib/terminfo`).

## Error handling (matches coreutils/ncurses)

| Condition | Message | Exit |
|---|---|---|
| `$TERM` unset | `tput: No value for $TERM and no -T specified` | 2 |
| unknown terminal | `tput: unknown terminal "NAME"` | 3 |
| unsupported capability | `tput: unknown terminfo capability 'NAME'` | 4 |
| no arguments | `Usage: tput [options] [command]` | 2 |

## Verification

`cols`/`lines` output and exit codes match the system `tput` **byte-for-byte**:
- terminfo fallback path (stdout redirected) across `xterm`, `xterm-256color`, `vt100`, `linux`, `screen`, `dumb`;
- live ioctl path over a pty across several window sizes (40×123, 24×80, 50×200);
- `COLUMNS`/`LINES` override beating both ioctl and terminfo;
- all four error/edge cases above.

The one intentional deviation: for the no-argument case I emit only the concise first usage line (matching coreutils' first line and exit 2). coreutils prints a longer, ncurses-version-specific options block that isn't portable to match.

## Notes

- Parameterized string capabilities (the terminfo `%` stack language used by `clear`, `bold`, `setaf`, …) are out of scope.
- Flips the `Baloo.json` catalog entry to done and regenerates the README catalog/progress badge.
- Adds five smoke tests: terminfo fallback (`cols`/`lines`), the pty-backed live-size path, unknown terminal, and unsupported capability.
- All 130 binaries build; `asmfmt --check` and README link checks pass.

https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_