### PR TITLE
Remove sed, ed, awk, and sh from the catalog

### DIFF
--- a/Baloo.json
+++ b/Baloo.json
@@ -24,12 +24,6 @@
     "isDone": true
   },
   {
-    "name": "awk",
-    "description": "Pattern scanning and processing language",
-    "glyph": "🧵",
-    "isDone": false
-  },
-  {
     "name": "b2sum",
     "description": "Computes and checks BLAKE2b message digest",
     "glyph": "🧪",
@@ -208,12 +202,6 @@
     "description": "Displays a specified line of text",
     "glyph": "🗣️",
     "isDone": true
-  },
-  {
-    "name": "ed",
-    "description": "The standard text editor",
-    "glyph": "📝",
-    "isDone": false
   },
   {
     "name": "env",
@@ -624,22 +612,10 @@
     "isDone": true
   },
   {
-    "name": "sed",
-    "description": "Stream editor",
-    "glyph": "🔧",
-    "isDone": false
-  },
-  {
     "name": "seq",
     "description": "Prints a sequence of numbers",
     "glyph": "🔄",
     "isDone": true
-  },
-  {
-    "name": "sh",
-    "description": "Shell, the standard command language interpreter",
-    "glyph": "🐚",
-    "isDone": false
   },
   {
     "name": "sha1sum",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baloo 🐻 
 
-![Progress](https://img.shields.io/badge/progress-150%2F154%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/Baloo.yml/badge.svg)
+![Progress](https://img.shields.io/badge/progress-150%2F150%20done-brightgreen) ![Build Status](https://github.com/seanwevans/baloo/actions/workflows/Baloo.yml/badge.svg)
 
 Just the bear utilities in x86_64 assembly using direct syscalls only — no libc or dependencies.
 
@@ -41,7 +41,6 @@ Commands:
 - [`ar`](src/ar.asm) ✅ Creates and maintains libraries
 - [`arch`](src/arch.asm) ✅ Prints machine hardware name
 - [`at`](src/at.asm) ✅ Executes commands at a later time
-- `awk` ⛔️ Pattern scanning and processing language
 - [`b2sum`](src/b2sum.asm) ✅ Computes and checks BLAKE2b message digest
 - [`base32`](src/base32.asm) ✅ Encodes or decodes Base32, and prints result to standard output
 - [`base64`](src/base64.asm) ✅ Encodes or decodes Base64, and prints result to standard output
@@ -72,7 +71,6 @@ Commands:
 - [`dirname`](src/dirname.asm) ✅ Strips non-directory suffix from file name
 - [`du`](src/du.asm) ✅ Shows disk usage on file systems
 - [`echo`](src/echo.asm) ✅ Displays a specified line of text
-- `ed` ⛔️ The standard text editor
 - [`env`](src/env.asm) ✅ Run a program in a modified environment
 - [`expand`](src/expand.asm) ✅ Converts tabs to spaces
 - [`expr`](src/expr.asm) ✅ Evaluates expressions
@@ -141,9 +139,7 @@ Commands:
 - [`rm`](src/rm.asm) ✅ Removes files/directories
 - [`rmdir`](src/rmdir.asm) ✅ Removes empty directories
 - [`runcon`](src/runcon.asm) ✅ Run command with specified security context
-- `sed` ⛔️ Stream editor
 - [`seq`](src/seq.asm) ✅ Prints a sequence of numbers
-- `sh` ⛔️ Shell, the standard command language interpreter
 - [`sha1sum`](src/sha1sum.asm) ✅ Computes and checks SHA-1/SHA-2 message digests
 - [`sha224sum`](src/sha224sum.asm) ✅ Computes and checks SHA-1/SHA-2 message digests
 - [`sha256sum`](src/sha256sum.asm) ✅ Computes and checks SHA-1/SHA-2 message digests


### PR DESCRIPTION
## Summary

Removes the `sed`, `ed`, `awk`, and `sh` entries from the project.

All four were placeholder catalog entries with **no implementation** — there were no `src/*.asm` files, no built binaries, no tests, and no build rules referencing them (the Makefile globs `src/*.asm`). The only references anywhere in the repo were the four `Baloo.json` entries and their auto-generated README rows.

## Changes

- Drop the four objects from `Baloo.json` (now 150 entries).
- Regenerate `README.md` via `scripts/update_readme.py`: the four catalog rows are gone and the progress badge updates **154 → 150**.

Since these were the only remaining unimplemented entries, the catalog now reads **150/150 done**.

## Verification

- `Baloo.json` parses as valid JSON; none of `sed`/`ed`/`awk`/`sh` remain.
- `make` builds all 150 binaries; `asmfmt --check` and `check_readme_links.py` pass.
- Diff is scoped to `Baloo.json` and `README.md` only.

https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_