### PR TITLE
Fix POSIX behavior bugs surfaced by Toybox tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/*
 build/*
+tests/test_helper/
 *.txt
 *.log
 *.bak

--- a/src/base32.asm
+++ b/src/base32.asm
@@ -15,10 +15,10 @@ global      _start
 
 _start:
     pop         rax                     ;Get argc
-    pop         rax                     ;skip program name
-    cmp         rax, 0
+    pop         rcx                     ;skip program name (argv[0])
+    dec         rax                     ;remaining args = argc - 1
 
-    jle         use_stdin               ;If no args, read from stdin
+    jle         use_stdin               ;If no file args, read from stdin
 
     pop         rsi                     ;Get filename
 

--- a/src/base64.asm
+++ b/src/base64.asm
@@ -16,10 +16,10 @@ global      _start
 
 _start:
     pop         rax                     ;Get argc
-    pop         rax                     ;skip program name
-    cmp         rax, 0
+    pop         rcx                     ;skip program name (argv[0])
+    dec         rax                     ;remaining args = argc - 1
 
-    jle         use_stdin               ;If no args, read from stdin
+    jle         use_stdin               ;If no file args, read from stdin
 
     pop         rsi                     ;Get filename
 

--- a/src/basename.asm
+++ b/src/basename.asm
@@ -6,6 +6,7 @@ section .bss
 
 section .data
     nl          db WHITESPACE_NL
+    slash       db "/"
 err_msg     db "basename: missing operand", 10
     err_len     equ $ - err_msg
 
@@ -13,20 +14,41 @@ section .text
 global      _start
 
 _start:
-    mov         rsi, rsp
-    mov         rdi, [rsi]              ;argc
-    cmp         rdi, 2                  ;need at least 1 argument after program name
+    mov         r14, [rsp]              ;argc
+    cmp         r14, 2                  ;need at least 1 operand
     jl          missing_operand
 
-    add         rsi, 8                  ;skip argc
-    add         rsi, 8                  ;skip argv[0]
-    mov         rsi, [rsi]              ;rsi = argv[1]
-    call        find_basename
+    mov         rsi, [rsp + 16]         ;rsi = argv[1]
+    call        find_basename           ;rsi = component start, rbx = length
+    mov         r12, rsi                ;save component start
+    mov         r13, rbx                ;save component length
 
-    mov         rbx, rsi
-    call        strlen
+    cmp         r14, 3                  ;optional suffix operand present?
+    jl          .emit
 
-    write       STDOUT_FILENO, rsi, rbx
+    mov         rsi, [rsp + 24]         ;rsi = argv[2] = suffix
+    call        strlen                  ;rbx = suffix length
+    test        rbx, rbx
+    jz          .emit                   ;empty suffix -> nothing to strip
+    cmp         rbx, r13
+    jae         .emit                   ;suffix not shorter than name -> keep whole
+
+    lea         r8, [r12 + r13]         ;end of the component
+    sub         r8, rbx                 ;start of its trailing slice
+    mov         r9, rsi                 ;suffix pointer
+    mov         rcx, rbx                ;suffix length
+.cmp_suffix:
+    mov         al, [r8]
+    cmp         al, [r9]
+    jne         .emit                   ;tail != suffix -> keep whole
+    inc         r8
+    inc         r9
+    dec         rcx
+    jnz         .cmp_suffix
+    sub         r13, rbx                ;strip the matched suffix
+
+.emit:
+    write       STDOUT_FILENO, r12, r13
     write       STDOUT_FILENO, nl, 1
     exit        0
 
@@ -34,20 +56,50 @@ missing_operand:
     write       STDERR_FILENO, err_msg, err_len
     exit        1
 
+; find_basename: rsi = path -> rsi = start of last component, rbx = its length.
+;   Trailing '/' are stripped; an all-slash path yields "/", "" yields length 0.
 find_basename:
-    mov         rbx, rsi
+    mov         r10, rsi                ;r10 = start of string
+    call        strlen                  ;rbx = strlen(rsi)
+    mov         r8, rbx                 ;r8 = end index
 
-.next:
-    cmp         byte [rbx], 0
-    je          .done
-    cmp         byte [rbx], '/'
-    jne         .advance
-    mov         rsi, rbx
-    inc         rsi
+.strip_trailing:
+    test        r8, r8
+    jz          .all_slashes
+    cmp         byte [r10 + r8 - 1], '/'
+    jne         .find_last
+    dec         r8
+    jmp         .strip_trailing
 
-.advance:
-    inc         rbx
-    jmp         .next
+.all_slashes:
+    test        rbx, rbx                ;original length
+    jz          .empty                  ;empty operand -> length 0
+    mov         rsi, slash              ;all-slash path -> "/"
+    mov         rbx, 1
+    ret
 
-.done:
+.empty:
+    mov         rsi, r10
+    xor         rbx, rbx
+    ret
+
+.find_last:
+    mov         r9, r8                  ;r9 = scan index
+.scan_back:
+    test        r9, r9
+    jz          .no_slash
+    cmp         byte [r10 + r9 - 1], '/'
+    je          .have_start
+    dec         r9
+    jmp         .scan_back
+
+.no_slash:
+    mov         rsi, r10
+    mov         rbx, r8
+    ret
+
+.have_start:
+    lea         rsi, [r10 + r9]         ;skip past the last '/'
+    mov         rbx, r8
+    sub         rbx, r9
     ret

--- a/src/dirname.asm
+++ b/src/dirname.asm
@@ -7,6 +7,7 @@ section .bss
 section .data
     dot         db ".", 0
     newline     db WHITESPACE_NL
+    slash       db "/"
 err_msg     db "dirname: missing operand", 10
     err_len     equ $ - err_msg
 
@@ -23,33 +24,58 @@ _start:
     add         rsi, 8                  ;skip argv[0]
     mov         rsi, [rsi]              ;rsi = argv[1]
 
-    call        strlen
-    dec         rbx                     ;rbx = strlen - 1
-    mov         rcx, rbx
+    mov         r10, rsi                ;r10 = start of string
+    call        strlen                  ;rbx = length
+    mov         r11, rbx                ;r11 = original length
+    mov         r8, rbx                 ;r8 = end index
 
+.strip_trailing:
+    test        r8, r8
+    jz          .root_or_dot
+    cmp         byte [r10 + r8 - 1], '/'
+    jne         .find_slash
+    dec         r8
+    jmp         .strip_trailing
+
+.root_or_dot:
+    test        r11, r11                ;empty operand -> "."
+    jz          .dot
+    jmp         .root                   ;all-slash operand -> "/"
+
+.find_slash:
+    mov         r9, r8                  ;scan back for the last '/'
 .scan:
-    cmp         rcx, 0
-    je          .noslash
-    cmp         byte [rsi + rcx], '/'
-    je          .found
-    dec         rcx
+    test        r9, r9
+    jz          .dot                    ;no '/' -> "."
+    cmp         byte [r10 + r9 - 1], '/'
+    je          .strip_mid
+    dec         r9
     jmp         .scan
 
-.noslash:
-    mov         rsi, dot
-    mov         rbx, 1
-    jmp         .print
+.strip_mid:
+    test        r9, r9                  ;drop the trailing separators
+    jz          .root                   ;leading '/' only -> "/"
+    cmp         byte [r10 + r9 - 1], '/'
+    jne         .emit
+    dec         r9
+    jmp         .strip_mid
 
-.found:
-    mov         byte [rsi + rcx], 0
-    mov         rbx, rcx
-    jmp         .print
+.emit:
+    write       STDOUT_FILENO, r10, r9
+    jmp         .put_nl
 
-.print:
-    write       1, rsi, rbx
-    write       1, newline, 1
+.root:
+    write       STDOUT_FILENO, slash, 1
+    jmp         .put_nl
+
+.dot:
+    write       STDOUT_FILENO, dot, 1
+    jmp         .put_nl
+
+.put_nl:
+    write       STDOUT_FILENO, newline, 1
     exit        0
 
 .missing_operand:
-    write       2, err_msg, err_len
+    write       STDERR_FILENO, err_msg, err_len
     exit        1

--- a/src/echo.asm
+++ b/src/echo.asm
@@ -7,40 +7,44 @@ section .bss
 
 section .data
     newline     db WHITESPACE_NL
+    space       db " "
 
 section .text
 global      _start
 
 _start:
     mov         rsi, rsp
-    mov         rdi, [rsi]              ;argc
-    add         rsi, 8                  ;argv[0]
-    add         rsi, 8                  ;argv[1]
+    mov         r12, [rsi]              ;argc
+    lea         r13, [rsi + 16]         ;&argv[1]
     mov         byte [no_newline], 0
-    cmp         rdi, 1
-    jle         .done
+    dec         r12                     ;operand count = argc - 1
+    jle         .maybe_nl               ;no operands -> just a newline
 
-    mov         rbx, [rsi]              ;first argument
-    mov         al, [rbx]
-    cmp         al, '-'
-    jne         .use_arg
+    mov         rbx, [r13]              ;first operand
+    cmp         byte [rbx], '-'
+    jne         .args_loop
     cmp         byte [rbx + 1], 'n'
-    jne         .use_arg
+    jne         .args_loop
     cmp         byte [rbx + 2], 0
-    jne         .use_arg
-    mov         byte [no_newline], 1
-    add         rsi, 8                  ;skip -n
-    dec         rdi
-.use_arg:
-    cmp         rdi, 1
-    jl          .maybe_nl
-    mov         rsi, [rsi]
+    jne         .args_loop
+    mov         byte [no_newline], 1    ;suppress trailing newline (-n)
+    add         r13, 8                  ;skip -n
+    dec         r12
+    jle         .maybe_nl               ;nothing left to print
+
+.args_loop:
+    mov         rsi, [r13]
     call        strlen
-    write       1, rsi, rbx
+    write       STDOUT_FILENO, rsi, rbx
+    dec         r12
+    jz          .maybe_nl               ;last operand -> no trailing space
+    write       STDOUT_FILENO, space, 1
+    add         r13, 8
+    jmp         .args_loop
 
 .maybe_nl:
     cmp         byte [no_newline], 1
     je          .done
-    write       1, newline, 1
+    write       STDOUT_FILENO, newline, 1
 .done:
     exit        0


### PR DESCRIPTION
## Summary

The Toybox compliance testing surfaced several real POSIX-behavior bugs. This fixes the clear ones, each verified **byte-for-byte against coreutils** and against the Toybox test suite.

| Utility | Bug | Fix |
|---|---|---|
| **base64 / base32** | The second `pop` clobbered `argc` with the `argv[0]` pointer, so the "no file arg" check tested a pointer (never ≤0). Piping data in opened a NULL filename and exited with no output — stdin was unreachable. | Decrement the real `argc`; a missing file operand now reads stdin. |
| **echo** | Only printed the *first* operand, and printed nothing at all with no operands. | Print every operand space-separated, keep `-n`, and emit a newline when given no operands. |
| **basename** | Never stripped trailing slashes (`///////`→empty, `/usr/bin/`→wrong component) and ignored the suffix operand. | Handle trailing/all-slash paths per POSIX; strip a matching, non-identical suffix. |
| **dirname** | Never stripped trailing slashes; returned `.` for `/`. | Strip trailing slashes and the final component per POSIX. |

## Verification

- **Byte-for-byte vs coreutils** across many inputs (empty, single/multi-arg, `-n`, suffix match/no-match/equal, `/`, `///////`, `/usr/bin/`, `a/b/c`, …) — all match.
- **Toybox tests**: each utility now passes its POSIX cases. `echo` 1→6 passing, `basename` 3→9, and the originally-failing `base64/base32` stdin, `echo` no-args, and `basename`/`dirname` slash cases are green.
- **Full repo bats suite: 167/167 pass** — no regressions. All five files pass `asmfmt --check`; full build (150 binaries) succeeds.

## Out of scope (remaining Toybox failures)

These are unimplemented **features / GNU extensions**, not POSIX bugs, and are left for a focused follow-up:
- `base64 -d` / `base32 -d` decode mode (these utilities are currently encode-only)
- `echo -e` backslash-escape interpretation
- `basename -s SUFFIX` and `dirname` with multiple operands (GNU extensions)

Separately, `cksum` uses the zlib CRC table rather than the POSIX `cksum` CRC (poly 0x04C11DB7 with the length appended), and `dd` ignores `count=`/`ibs=` — both are larger rewrites worth their own PR.

https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx

---
_Generated by [Claude Code](https://claude.ai/code/session_017BASerqucxE9LXxX3C8rfx)_