### PR TITLE
Add Makefile install and uninstall targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,12 @@ FMT_FILES := $(SRC) $(INC)
 FMT_SCRIPT := scripts/asmfmt.py
 README_SCRIPT := scripts/update_readme.py
 TEST_FLAGS ?= --timing
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+INSTALL ?= install
+INSTALL_PROGRAM ?= $(INSTALL) -m 755
 
-.PHONY: all setup clean test format lint-format update-readme check-readme check-readme-links
+.PHONY: all setup install uninstall clean test format lint-format update-readme check-readme check-readme-links
 
 .SECONDARY: $(OBJ)
 
@@ -40,6 +44,13 @@ lint-format:
 
 test: all
 	bats $(TEST_FLAGS) tests/test_all.bats
+
+install: all
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL_PROGRAM) $(BIN) $(DESTDIR)$(BINDIR)/
+
+uninstall:
+	rm -f $(addprefix $(DESTDIR)$(BINDIR)/,$(notdir $(BIN)))
 
 check-readme-links:
 	python3 scripts/check_readme_links.py


### PR DESCRIPTION
### Motivation
- Provide a standard way for users to install the compiled `bin/` outputs into a system or user prefix (e.g. `~/.local/bin` or `/usr/local/bin`).

### Description
- Add configurable install variables `PREFIX`, `BINDIR`, `INSTALL`, and `INSTALL_PROGRAM` with `PREFIX` defaulting to `/usr/local`.
- Register `install` and `uninstall` in `.PHONY` and add an `install` target that runs `all`, creates `$(DESTDIR)$(BINDIR)` and installs `$(BIN)` there using `$(INSTALL_PROGRAM)`.
- Add an `uninstall` target that removes the installed binaries via `rm -f $(addprefix $(DESTDIR)$(BINDIR)/,$(notdir $(BIN)))`.

### Testing
- Ran `git diff --check` which produced no issues and passed. 
- Ran `make lint-format` which completed successfully. 
- Verified `make install DESTDIR="$tmpdir" PREFIX=/usr/local` created files under `$tmpdir/usr/local/bin` and `make uninstall DESTDIR="$tmpdir" PREFIX=/usr/local` removed them, both succeeding. 
- `make test` failed because `bats` is not installed in the environment (expected test dependency failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283a369fdc8328bb4cee3f4155195b)