### PR TITLE
Improve seq toybox error handling

### DIFF
--- a/src/seq.asm
+++ b/src/seq.asm
@@ -119,11 +119,11 @@ print_number:
     jmp             sequence_loop       ;Continue loop
 
 print_usage:
-    write           STDOUT_FILENO, usage_msg, usage_len
+    write           STDERR_FILENO, usage_msg, usage_len
     exit            1
 
 print_overflow:
-    write           STDOUT_FILENO, overflow_msg, overflow_len
+    write           STDERR_FILENO, overflow_msg, overflow_len
     exit            1
 
 end_program:


### PR DESCRIPTION
### Motivation
- Route `seq` diagnostic output to the correct stream so tests that redirect stderr can examine `stdout` unpolluted by usage/overflow messages (Toybox compatibility). 

### Description
- Changed `src/seq.asm` to write `usage` and `overflow` diagnostics to `STDERR_FILENO` instead of `STDOUT_FILENO` so error messages are emitted on the error stream. 

### Testing
- Built the binary with `make bin/seq` and ran the Toybox `seq` tests by symlinking `/tmp/baloo_compliance_env/symlink_farm/seq` to `bin/seq` and invoking `TEST_HOST=1 scripts/test.sh seq`, which increased Toybox `PASS`es from 0 to 12 with one remaining decimal-sequence failure. 
- Ran `make lint-format` successfully; `make test` could not be executed in this environment because `bats` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a289ee537e483288daa6d5ee55a543b)