### PR TITLE
Support multiple dirname operands

### DIFF
--- a/src/dirname.asm
+++ b/src/dirname.asm
@@ -20,9 +20,12 @@ _start:
     cmp         rdi, 2                  ;need at least argv[1]
     jl          .missing_operand
 
-    add         rsi, 8                  ;skip argc
-    add         rsi, 8                  ;skip argv[0]
-    mov         rsi, [rsi]              ;rsi = argv[1]
+    lea         r12, [rsi + 16]         ;r12 = argv[1]
+    mov         r13, rdi
+    dec         r13                     ;number of path operands
+
+.next_operand:
+    mov         rsi, [r12]              ;rsi = current operand
 
     mov         r10, rsi                ;r10 = start of string
     call        strlen                  ;rbx = length
@@ -74,6 +77,9 @@ _start:
 
 .put_nl:
     write       STDOUT_FILENO, newline, 1
+    add         r12, 8
+    dec         r13
+    jnz         .next_operand
     exit        0
 
 .missing_operand:


### PR DESCRIPTION
### Motivation
- `dirname` previously processed only `argv[1]` and did not emit results for additional path operands passed on the command line.
- The change aims to make `dirname` behave like coreutils/toybox by printing one normalized dirname per operand when multiple arguments are supplied.

### Description
- Update `src/dirname.asm` to keep an argv pointer/count in `r12`/`r13` and iterate over every path operand rather than only handling the first one.
- Add a `.next_operand` entry point and loop continuation after emitting each result so each argument produces one output line.
- Preserve the existing path-normalization logic (trailing-slash stripping, root/dot heuristics) and only add the operand iteration plumbing.

### Testing
- Built the binary with `make bin/dirname` which succeeded.
- Ran the Toybox `dirname` tests via `scripts/test.sh dirname` with the built binary and all `dirname` test cases passed.
- Ran `make lint-format` which succeeded, and `make test` failed because automated test runner `bats` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a295c38f82883289699d4cdc47f6d97)