### PR TITLE
Improve cut range handling

### DIFF
--- a/src/cut.asm
+++ b/src/cut.asm
@@ -2,80 +2,100 @@
 
     %include "include/sysdefs.inc"
 
+    %define MAX_RANGES 128
+    %define OPEN_END 0x7fffffffffffffff
+
 section .bss
-    buffer      resb 1                  ;Input buffer
-    bytes_limit resq 1                  ;Number of characters to keep per line
-    fd          resq 1                  ;File descriptor
+    buffer       resb 1
+    fd           resq 1
+    ranges_start resq MAX_RANGES
+    ranges_end   resq MAX_RANGES
+    range_count  resq 1
 
 section .data
-usage_msg   db "Usage: cut -c NUM [FILE]", 10
+usage_msg   db "Usage: cut -b LIST [FILE]", 10
     usage_len   equ $ - usage_msg
 
 section .text
 global _start
 
 _start:
-    pop rbx                             ;argc
     mov qword [fd], STDIN_FILENO
-    pop rax                             ;skip argv[0]
-    dec rbx
-    cmp rbx, 0
+    mov qword [range_count], 0
+
+    pop r12                             ;argc
+    pop rax                             ;argv[0]
+    dec r12
     jle usage
 
-    pop rdi                             ;first arg
-    dec rbx
+parse_args:
+    test r12, r12
+    jz process
+
+    pop rdi
+    dec r12
+
     cmp byte [rdi], '-'
-    jne usage
-    cmp byte [rdi+1], 'c'
-    jne usage
+    jne open_input
 
-    cmp rbx, 0
-    jle usage
-    pop rdi                             ;NUM
-    dec rbx
-    call atoi
-    test rax, rax
-    jle usage
-    mov [bytes_limit], rax
+    mov al, [rdi + 1]
+    cmp al, 'b'
+    je range_option
+    cmp al, 'c'
+    je range_option
+    jmp usage
 
-    cmp rbx, 0
-    jle process
-    pop rsi                             ;FILE
-    dec rbx
+range_option:
+    cmp byte [rdi + 2], 0
+    jne inline_range
+    test r12, r12
+    jz usage
+    pop rdi
+    dec r12
+    jmp parse_range_arg
+
+inline_range:
+    lea rdi, [rdi + 2]
+
+parse_range_arg:
+    call parse_ranges
+    jmp parse_args
+
+open_input:
+    mov rsi, rdi
     mov rdi, STDIN_FILENO
     call open_file
     mov [fd], rax
+    jmp parse_args
 
 process:
-    xor r8, r8                          ;char counter
+    cmp qword [range_count], 0
+    je usage
+
+    xor r12, r12                        ;1-based byte/character position in line
 read_loop:
     mov rax, SYS_READ
     mov rdi, [fd]
     mov rsi, buffer
     mov rdx, 1
     syscall
-
     cmp rax, 0
     jle done
 
-    movzx rax, byte [buffer]
-    cmp al, WHITESPACE_NL
-    jne check_print
-    mov r8, 0
-    jmp print_char
+    cmp byte [buffer], WHITESPACE_NL
+    je print_newline
 
-check_print:
-    inc r8
-    mov rdx, [bytes_limit]
-    cmp r8, rdx
-    jg read_loop
+    inc r12
+    mov rdi, r12
+    call is_selected
+    test rax, rax
+    jz read_loop
+    call write_buffer
+    jmp read_loop
 
-print_char:
-    mov rax, SYS_WRITE
-    mov rdi, STDOUT_FILENO
-    mov rsi, buffer
-    mov rdx, 1
-    syscall
+print_newline:
+    call write_buffer
+    xor r12, r12
     jmp read_loop
 
 done:
@@ -92,25 +112,124 @@ usage:
     write STDERR_FILENO, usage_msg, usage_len
     exit 1
 
-; Convert decimal string to integer in rax
-atoi:
+write_buffer:
+    mov rax, SYS_WRITE
+    mov rdi, STDOUT_FILENO
+    mov rsi, buffer
+    mov rdx, 1
+    syscall
+    ret
+
+; rdi = 1-based position. returns rax=1 when any range contains it.
+is_selected:
+    xor rcx, rcx
+    mov r8, [range_count]
+.check_loop:
+    cmp rcx, r8
+    jae .no
+    mov rax, [ranges_start + rcx * 8]
+    cmp rdi, rax
+    jb .next
+    mov rax, [ranges_end + rcx * 8]
+    cmp rdi, rax
+    jbe .yes
+.next:
+    inc rcx
+    jmp .check_loop
+.yes:
+    mov rax, 1
+    ret
+.no:
+    xor rax, rax
+    ret
+
+; rdi = comma-separated list of N, N-M, N-, or -M ranges.
+parse_ranges:
+    mov rsi, rdi
+.next_range:
+    mov rax, [range_count]
+    cmp rax, MAX_RANGES
+    jae usage
+
+    xor r8, r8                          ;start
+    xor r9, r9                          ;end
+
+    cmp byte [rsi], '-'
+    je .leading_dash
+
+    call parse_number                   ;rax=number, rsi=next char
+    test rax, rax
+    jz usage
+    mov r8, rax
+    mov r9, rax
+
+    cmp byte [rsi], '-'
+    jne .finish_range
+    inc rsi
+    cmp byte [rsi], 0
+    je .open_ended
+    cmp byte [rsi], ','
+    je .open_ended
+
+    call parse_number
+    test rax, rax
+    jz usage
+    mov r9, rax
+    jmp .validate
+
+.leading_dash:
+    mov r8, 1
+    inc rsi
+    call parse_number
+    test rax, rax
+    jz usage
+    mov r9, rax
+    jmp .validate
+
+.open_ended:
+    mov r9, OPEN_END
+
+.validate:
+    cmp r9, r8
+    jb usage
+
+.finish_range:
+    mov rcx, [range_count]
+    mov [ranges_start + rcx * 8], r8
+    mov [ranges_end + rcx * 8], r9
+    inc rcx
+    mov [range_count], rcx
+
+    cmp byte [rsi], ','
+    jne .done
+    inc rsi
+    cmp byte [rsi], 0
+    je usage
+    jmp .next_range
+.done:
+    cmp byte [rsi], 0
+    jne usage
+    ret
+
+; rsi points at decimal digits. returns rax=number and advances rsi.
+parse_number:
     xor rax, rax
     xor rcx, rcx
-atoi_loop:
-    movzx r9, byte [rdi + rcx]
-    test r9, r9
-    jz atoi_done
-    cmp r9, '0'
-    jl atoi_error
-    cmp r9, '9'
-    jg atoi_error
+.loop:
+    movzx rdx, byte [rsi]
+    cmp rdx, '0'
+    jb .done
+    cmp rdx, '9'
+    ja .done
     imul rax, 10
-    sub r9, '0'
-    add rax, r9
+    sub rdx, '0'
+    add rax, rdx
+    inc rsi
     inc rcx
-    jmp atoi_loop
-atoi_done:
-    ret
-atoi_error:
+    jmp .loop
+.done:
+    test rcx, rcx
+    jnz .have_digits
     xor rax, rax
+.have_digits:
     ret


### PR DESCRIPTION
### Motivation
- Make the `cut` utility accept POSIX/Toybox-style range lists (both `-b` and `-c` forms) instead of the previous single-number-only behavior to satisfy Toybox compatibility tests. 
- Support comma-separated ranges, leading ranges, open-ended ranges and validate high-to-low ranges so test expectations are met. 
- Preserve per-line semantics so newline boundaries reset position counting and overlapping ranges do not produce duplicate output.

### Description
- Added `MAX_RANGES` and `OPEN_END` defines and allocated `ranges_start`, `ranges_end`, and `range_count` storage in `.bss`. 
- Reworked argument parsing to accept inline (`-bLIST`) and separate-argument (`-b LIST`) forms and to handle both `-b` and `-c` options. 
- Implemented `parse_ranges` and `parse_number` to parse comma-separated `N`, `N-M`, `N-`, and `-M` range forms with validation, and store ranges into the arrays. 
- Replaced the old byte-limit logic with per-line position counting, added `is_selected` and `write_buffer` helpers to emit selected bytes and to reset counting at newlines, and updated the usage message.

### Testing
- Built locally with `make -j$(nproc)` and ran `make lint-format`, both of which completed successfully. 
- Exercised the Toybox test driver by running `PATH=/tmp/baloo_cut_farm:$PATH TEST_HOST=1 scripts/test.sh cut` against the updated `bin/cut`, which produced 9 passing Toybox tests, 1 failing test (`cut empty field`), and 5 skipped tests. 
- `make test` could not be executed in the environment because the `bats` test harness is not installed, so the repository-level test target was not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c42519f2c8328b65d34b7f1847278)