### PR TITLE
Fix cut smoke test range

### DIFF
--- a/tests/test_all.bats
+++ b/tests/test_all.bats
@@ -185,8 +185,8 @@ PY
 
 @test "cut — first 3 chars" {
   printf "abcdef\n" >"$TMP/cutfile"
-  run "$BIN/cut" -c 3 "$TMP/cutfile"
-  assert_output --partial "abc"
+  run "$BIN/cut" -c 1-3 "$TMP/cutfile"
+  assert_output "abc"
 }
 
 @test "csplit — splits at line" {


### PR DESCRIPTION
### Motivation

- The `cut` smoke test requested the third character only (`-c 3`) while the test name expects the first three characters, causing a false negative.
- The assertion used a partial match which allowed ambiguous results instead of verifying the exact expected output.

### Description

- Updated `tests/test_all.bats` to run `cut` with an explicit `-c 1-3` range for the "first 3 chars" test.
- Replaced the loose `assert_output --partial "abc"` check with an exact `assert_output "abc"` assertion.
- The change is limited to the single smoke test for `cut` in `tests/test_all.bats`.

### Testing

- Ran `make test` (after installing `bats` and the `bats-support` / `bats-assert` helper libraries) and the full test suite completed with all smoke tests passing (`1..167` all OK).
- Verified repository formatting/consistency with `git diff --check` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ffde809988328b2be0714bc9b9a25)