### PR TITLE
Document catalog as detailed table

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,186 +15,158 @@ So I built
 
 ## Catalog
 
-<table>
-  <tbody>
-    <tr>
-      <td align="center" title="tput" style="font-size: 1.5em; padding: 5px;"><a href="src/tput.asm" style="text-decoration: none;">🎮</a></td>
-      <td align="center" title="printf" style="font-size: 1.5em; padding: 5px;"><a href="src/printf.asm" style="text-decoration: none;">🖊️</a></td>
-      <td align="center" title="uptime" style="font-size: 1.5em; padding: 5px;"><a href="src/uptime.asm" style="text-decoration: none;">⏰</a></td>
-      <td align="center" title="stat" style="font-size: 1.5em; padding: 5px;"><a href="src/stat.asm" style="text-decoration: none;">📊</a></td>
-      <td align="center" title="pax" style="font-size: 1.5em; padding: 5px;"><a href="src/pax.asm" style="text-decoration: none;">📦</a></td>
-      <td align="center" title="kill" style="font-size: 1.5em; padding: 5px;"><a href="src/kill.asm" style="text-decoration: none;">💀</a></td>
-      <td align="center" title="ptx" style="font-size: 1.5em; padding: 5px;"><a href="src/ptx.asm" style="text-decoration: none;">📇</a></td>
-      <td align="center" title="sha512sum" style="font-size: 1.5em; padding: 5px;"><a href="src/sha512sum.asm" style="text-decoration: none;">🔑</a></td>
-      <td align="center" title="sha384sum" style="font-size: 1.5em; padding: 5px;"><a href="src/sha384sum.asm" style="text-decoration: none;">🔓</a></td>
-      <td align="center" title="cmp" style="font-size: 1.5em; padding: 5px;"><a href="src/cmp.asm" style="text-decoration: none;">🔬</a></td>
-      <td align="center" title="sha224sum" style="font-size: 1.5em; padding: 5px;"><a href="src/sha224sum.asm" style="text-decoration: none;">🔐</a></td>
-      <td align="center" title="sha256sum" style="font-size: 1.5em; padding: 5px;"><a href="src/sha256sum.asm" style="text-decoration: none;">🔒</a></td>
-    </tr>
-    <tr>
-      <td align="center" title="comm" style="font-size: 1.5em; padding: 5px;"><a href="src/comm.asm" style="text-decoration: none;">☯️</a></td>
-      <td align="center" title="whoami" style="font-size: 1.5em; padding: 5px;"><a href="src/whoami.asm" style="text-decoration: none;">🙋</a></td>
-      <td align="center" title="tail" style="font-size: 1.5em; padding: 5px;"><a href="src/tail.asm" style="text-decoration: none;">⬇️</a></td>
-      <td align="center" title="sort" style="font-size: 1.5em; padding: 5px;"><a href="src/sort.asm" style="text-decoration: none;">🔠</a></td>
-      <td align="center" title="seq" style="font-size: 1.5em; padding: 5px;"><a href="src/seq.asm" style="text-decoration: none;">🔄</a></td>
-      <td align="center" title="mktemp" style="font-size: 1.5em; padding: 5px;"><a href="src/mktemp.asm" style="text-decoration: none;">📜</a></td>
-      <td align="center" title="fold" style="font-size: 1.5em; padding: 5px;"><a href="src/fold.asm" style="text-decoration: none;">📃</a></td>
-      <td align="center" title="bc" style="font-size: 1.5em; padding: 5px;"><a href="src/bc.asm" style="text-decoration: none;">🧮</a></td>
-      <td align="center" title="wc" style="font-size: 1.5em; padding: 5px;"><a href="src/wc.asm" style="text-decoration: none;">🔡</a></td>
-      <td align="center" title="factor" style="font-size: 1.5em; padding: 5px;"><a href="src/factor.asm" style="text-decoration: none;">🔢</a></td>
-      <td align="center" title="uniq" style="font-size: 1.5em; padding: 5px;"><a href="src/uniq.asm" style="text-decoration: none;">🎯</a></td>
-      <td align="center" title="tsort" style="font-size: 1.5em; padding: 5px;"><a href="src/tsort.asm" style="text-decoration: none;">🧶</a></td>
-    </tr>
-    <tr>
-      <td align="center" title="base32" style="font-size: 1.5em; padding: 5px;"><a href="src/base32.asm" style="text-decoration: none;">3️⃣</a></td>
-      <td align="center" title="logname" style="font-size: 1.5em; padding: 5px;"><a href="src/logname.asm" style="text-decoration: none;">👤</a></td>
-      <td align="center" title="tr" style="font-size: 1.5em; padding: 5px;"><a href="src/tr.asm" style="text-decoration: none;">🔡</a></td>
-      <td align="center" title="sha1sum" style="font-size: 1.5em; padding: 5px;"><a href="src/sha1sum.asm" style="text-decoration: none;">🔏</a></td>
-      <td align="center" title="cksum" style="font-size: 1.5em; padding: 5px;"><a href="src/cksum.asm" style="text-decoration: none;">🧾</a></td>
-      <td align="center" title="iconv" style="font-size: 1.5em; padding: 5px;"><a href="src/iconv.asm" style="text-decoration: none;">🔄</a></td>
-      <td align="center" title="who" style="font-size: 1.5em; padding: 5px;"><a href="src/who.asm" style="text-decoration: none;">👨‍👨‍👧‍👧</a></td>
-      <td align="center" title="join" style="font-size: 1.5em; padding: 5px;"><a href="src/join.asm" style="text-decoration: none;">🔗</a></td>
-      <td align="center" title="runcon" style="font-size: 1.5em; padding: 5px;"><a href="src/runcon.asm" style="text-decoration: none;">🔓</a></td>
-      <td align="center" title="base64" style="font-size: 1.5em; padding: 5px;"><a href="src/base64.asm" style="text-decoration: none;">6️⃣</a></td>
-      <td align="center" title="baseenc" style="font-size: 1.5em; padding: 5px;"><a href="src/baseenc.asm" style="text-decoration: none;">🔡</a></td>
-      <td align="center" title="stdbuf" style="font-size: 1.5em; padding: 5px;"><a href="src/stdbuf.asm" style="text-decoration: none;">📤</a></td>
-    </tr>
-    <tr>
-      <td align="center" title="xargs" style="font-size: 1.5em; padding: 5px;"><a href="src/xargs.asm" style="text-decoration: none;">🔨</a></td>
-      <td align="center" title="unexpand" style="font-size: 1.5em; padding: 5px;"><a href="src/unexpand.asm" style="text-decoration: none;">⬅️</a></td>
-      <td align="center" title="chown" style="font-size: 1.5em; padding: 5px;"><a href="src/chown.asm" style="text-decoration: none;">🔐</a></td>
-      <td align="center" title="cd" style="font-size: 1.5em; padding: 5px;"><a href="src/cd.asm" style="text-decoration: none;">🚶</a></td>
-      <td align="center" title="head" style="font-size: 1.5em; padding: 5px;"><a href="src/head.asm" style="text-decoration: none;">⬆️</a></td>
-      <td align="center" title="crontab" style="font-size: 1.5em; padding: 5px;"><a href="src/crontab.asm" style="text-decoration: none;">🗓️</a></td>
-      <td align="center" title="touch" style="font-size: 1.5em; padding: 5px;"><a href="src/touch.asm" style="text-decoration: none;">👆</a></td>
-      <td align="center" title="id" style="font-size: 1.5em; padding: 5px;"><a href="src/id.asm" style="text-decoration: none;">🆔</a></td>
-      <td align="center" title="shuf" style="font-size: 1.5em; padding: 5px;"><a href="src/shuf.asm" style="text-decoration: none;">🎲</a></td>
-      <td align="center" title="paste" style="font-size: 1.5em; padding: 5px;"><a href="src/paste.asm" style="text-decoration: none;">📌</a></td>
-      <td align="center" title="uudecode" style="font-size: 1.5em; padding: 5px;"><a href="src/uudecode.asm" style="text-decoration: none;">📩</a></td>
-      <td align="center" title="date" style="font-size: 1.5em; padding: 5px;"><a href="src/date.asm" style="text-decoration: none;">📅</a></td>
-    </tr>
-    <tr>
-      <td align="center" title="umask" style="font-size: 1.5em; padding: 5px;"><a href="src/umask.asm" style="text-decoration: none;">🎭</a></td>
-      <td align="center" title="unalias" style="font-size: 1.5em; padding: 5px;"><a href="src/unalias.asm" style="text-decoration: none;">🚫</a></td>
-      <td align="center" title="nl" style="font-size: 1.5em; padding: 5px;"><a href="src/nl.asm" style="text-decoration: none;">🔢</a></td>
-      <td align="center" title="test" style="font-size: 1.5em; padding: 5px;"><a href="src/test.asm" style="text-decoration: none;">🧪</a></td>
-      <td align="center" title="diff" style="font-size: 1.5em; padding: 5px;"><a href="src/diff.asm" style="text-decoration: none;">🔍</a></td>
-      <td align="center" title="ln" style="font-size: 1.5em; padding: 5px;"><a href="src/ln.asm" style="text-decoration: none;">🖇️</a></td>
-      <td align="center" title="getopts" style="font-size: 1.5em; padding: 5px;"><a href="src/getopts.asm" style="text-decoration: none;">🔣</a></td>
-      <td align="center" title="ls" style="font-size: 1.5em; padding: 5px;"><a href="src/ls.asm" style="text-decoration: none;">📋</a></td>
-      <td align="center" title="uuencode" style="font-size: 1.5em; padding: 5px;"><a href="src/uuencode.asm" style="text-decoration: none;">📫</a></td>
-      <td align="center" title="ps" style="font-size: 1.5em; padding: 5px;"><a href="src/ps.asm" style="text-decoration: none;">📈</a></td>
-      <td align="center" title="grep" style="font-size: 1.5em; padding: 5px;"><a href="src/grep.asm" style="text-decoration: none;">🔦</a></td>
-      <td align="center" title="users" style="font-size: 1.5em; padding: 5px;"><a href="src/users.asm" style="text-decoration: none;">👨‍👩‍👧‍👦</a></td>
-    </tr>
-    <tr>
-      <td align="center" title="basename" style="font-size: 1.5em; padding: 5px;"><a href="src/basename.asm" style="text-decoration: none;">🔤</a></td>
-      <td align="center" title="chroot" style="font-size: 1.5em; padding: 5px;"><a href="src/chroot.asm" style="text-decoration: none;">🌱</a></td>
-      <td align="center" title="link" style="font-size: 1.5em; padding: 5px;"><a href="src/link.asm" style="text-decoration: none;">🔗</a></td>
-      <td align="center" title="time" style="font-size: 1.5em; padding: 5px;"><a href="src/time.asm" style="text-decoration: none;">⏱️</a></td>
-      <td align="center" title="cp" style="font-size: 1.5em; padding: 5px;"><a href="src/cp.asm" style="text-decoration: none;">📑</a></td>
-      <td align="center" title="expand" style="font-size: 1.5em; padding: 5px;"><a href="src/expand.asm" style="text-decoration: none;">➡️</a></td>
-      <td align="center" title="lp" style="font-size: 1.5em; padding: 5px;"><a href="src/lp.asm" style="text-decoration: none;">🖨️</a></td>
-      <td align="center" title="sum" style="font-size: 1.5em; padding: 5px;"><a href="src/sum.asm" style="text-decoration: none;">➕</a></td>
-      <td align="center" title="ar" style="font-size: 1.5em; padding: 5px;"><a href="src/ar.asm" style="text-decoration: none;">🗄️</a></td>
-      <td align="center" title="dd" style="font-size: 1.5em; padding: 5px;"><a href="src/dd.asm" style="text-decoration: none;">💾</a></td>
-      <td align="center" title="chmod" style="font-size: 1.5em; padding: 5px;"><a href="src/chmod.asm" style="text-decoration: none;">🔒</a></td>
-      <td align="center" title="stty" style="font-size: 1.5em; padding: 5px;"><a href="src/stty.asm" style="text-decoration: none;">⌨️</a></td>
-    </tr>
-    <tr>
-      <td align="center" title="hostid" style="font-size: 1.5em; padding: 5px;"><a href="src/hostid.asm" style="text-decoration: none;">🏷️</a></td>
-      <td align="center" title="numfmt" style="font-size: 1.5em; padding: 5px;"><a href="src/numfmt.asm" style="text-decoration: none;">🔣</a></td>
-      <td align="center" title="expr" style="font-size: 1.5em; padding: 5px;"><a href="src/expr.asm" style="text-decoration: none;">📊</a></td>
-      <td align="center" title="csplit" style="font-size: 1.5em; padding: 5px;"><a href="src/csplit.asm" style="text-decoration: none;">📂</a></td>
-      <td align="center" title="find" style="font-size: 1.5em; padding: 5px;"><a href="src/find.asm" style="text-decoration: none;">🔎</a></td>
-      <td align="center" title="split" style="font-size: 1.5em; padding: 5px;"><a href="src/split.asm" style="text-decoration: none;">✂️</a></td>
-      <td align="center" title="b2sum" style="font-size: 1.5em; padding: 5px;"><a href="src/b2sum.asm" style="text-decoration: none;">🧪</a></td>
-      <td align="center" title="nproc" style="font-size: 1.5em; padding: 5px;"><a href="src/nproc.asm" style="text-decoration: none;">🖥️</a></td>
-      <td align="center" title="md5sum" style="font-size: 1.5em; padding: 5px;"><a href="src/md5sum.asm" style="text-decoration: none;">🔑</a></td>
-      <td align="center" title="getconf" style="font-size: 1.5em; padding: 5px;"><a href="src/getconf.asm" style="text-decoration: none;">⚙️</a></td>
-      <td align="center" title="truncate" style="font-size: 1.5em; padding: 5px;"><a href="src/truncate.asm" style="text-decoration: none;">📏</a></td>
-      <td align="center" title="mkfifo" style="font-size: 1.5em; padding: 5px;"><a href="src/mkfifo.asm" style="text-decoration: none;">📯</a></td>
-    </tr>
-    <tr>
-      <td align="center" title="nice" style="font-size: 1.5em; padding: 5px;"><a href="src/nice.asm" style="text-decoration: none;">👌</a></td>
-      <td align="center" title="readlink" style="font-size: 1.5em; padding: 5px;"><a href="src/readlink.asm" style="text-decoration: none;">👉</a></td>
-      <td align="center" title="shred" style="font-size: 1.5em; padding: 5px;"><a href="src/shred.asm" style="text-decoration: none;">🔪</a></td>
-      <td align="center" title="fmt" style="font-size: 1.5em; padding: 5px;"><a href="src/fmt.asm" style="text-decoration: none;">📐</a></td>
-      <td align="center" title="mv" style="font-size: 1.5em; padding: 5px;"><a href="src/mv.asm" style="text-decoration: none;">🚚</a></td>
-      <td align="center" title="printenv" style="font-size: 1.5em; padding: 5px;"><a href="src/printenv.asm" style="text-decoration: none;">🖼️</a></td>
-      <td align="center" title="at" style="font-size: 1.5em; padding: 5px;"><a href="src/at.asm" style="text-decoration: none;">⏰</a></td>
-      <td align="center" title="man" style="font-size: 1.5em; padding: 5px;"><a href="src/man.asm" style="text-decoration: none;">📚</a></td>
-      <td align="center" title="realpath" style="font-size: 1.5em; padding: 5px;"><a href="src/realpath.asm" style="text-decoration: none;">🛣️</a></td>
-      <td align="center" title="mesg" style="font-size: 1.5em; padding: 5px;"><a href="src/mesg.asm" style="text-decoration: none;">📨</a></td>
-      <td align="center" title="cat" style="font-size: 1.5em; padding: 5px;"><a href="src/cat.asm" style="text-decoration: none;">🐱</a></td>
-      <td align="center" title="renice" style="font-size: 1.5em; padding: 5px;"><a href="src/renice.asm" style="text-decoration: none;">👍</a></td>
-    </tr>
-    <tr>
-      <td align="center" title="mknod" style="font-size: 1.5em; padding: 5px;"><a href="src/mknod.asm" style="text-decoration: none;">🧩</a></td>
-      <td align="center" title="od" style="font-size: 1.5em; padding: 5px;"><a href="src/od.asm" style="text-decoration: none;">👁️</a></td>
-      <td align="center" title="tac" style="font-size: 1.5em; padding: 5px;"><a href="src/tac.asm" style="text-decoration: none;">🙃</a></td>
-      <td align="center" title="strings" style="font-size: 1.5em; padding: 5px;"><a href="src/strings.asm" style="text-decoration: none;">🔤</a></td>
-      <td align="center" title="dirname" style="font-size: 1.5em; padding: 5px;"><a href="src/dirname.asm" style="text-decoration: none;">📁</a></td>
-      <td align="center" title="cut" style="font-size: 1.5em; padding: 5px;"><a href="src/cut.asm" style="text-decoration: none;">✂️</a></td>
-      <td align="center" title="localedef" style="font-size: 1.5em; padding: 5px;"><a href="src/localedef.asm" style="text-decoration: none;">🌐</a></td>
-      <td align="center" title="gencat" style="font-size: 1.5em; padding: 5px;"><a href="src/gencat.asm" style="text-decoration: none;">😺</a></td>
-      <td align="center" title="newgrp" style="font-size: 1.5em; padding: 5px;"><a href="src/newgrp.asm" style="text-decoration: none;">👨‍👩‍👧</a></td>
-      <td align="center" title="chgrp" style="font-size: 1.5em; padding: 5px;"><a href="src/chgrp.asm" style="text-decoration: none;">👥</a></td>
-      <td align="center" title="install" style="font-size: 1.5em; padding: 5px;"><a href="src/install.asm" style="text-decoration: none;">📥</a></td>
-      <td align="center" title="du" style="font-size: 1.5em; padding: 5px;"><a href="src/du.asm" style="text-decoration: none;">📊</a></td>
-    </tr>
-    <tr>
-      <td align="center" title="pathchk" style="font-size: 1.5em; padding: 5px;"><a href="src/pathchk.asm" style="text-decoration: none;">✓</a></td>
-      <td align="center" title="locale" style="font-size: 1.5em; padding: 5px;"><a href="src/locale.asm" style="text-decoration: none;">🌍</a></td>
-      <td align="center" title="rmdir" style="font-size: 1.5em; padding: 5px;"><a href="src/rmdir.asm" style="text-decoration: none;">🗂️</a></td>
-      <td align="center" title="nohup" style="font-size: 1.5em; padding: 5px;"><a href="src/nohup.asm" style="text-decoration: none;">🏃</a></td>
-      <td align="center" title="tee" style="font-size: 1.5em; padding: 5px;"><a href="src/tee.asm" style="text-decoration: none;">🔱</a></td>
-      <td align="center" title="groups" style="font-size: 1.5em; padding: 5px;"><a href="src/groups.asm" style="text-decoration: none;">👪</a></td>
-      <td align="center" title="uname" style="font-size: 1.5em; padding: 5px;"><a href="src/uname.asm" style="text-decoration: none;">💻</a></td>
-      <td align="center" title="alias" style="font-size: 1.5em; padding: 5px;"><a href="src/alias.asm" style="text-decoration: none;">🏷️</a></td>
-      <td align="center" title="batch" style="font-size: 1.5em; padding: 5px;"><a href="src/batch.asm" style="text-decoration: none;">📚</a></td>
-      <td align="center" title="ngettext" style="font-size: 1.5em; padding: 5px;"><a href="src/ngettext.asm" style="text-decoration: none;">🗯️</a></td>
-      <td align="center" title="df" style="font-size: 1.5em; padding: 5px;"><a href="src/df.asm" style="text-decoration: none;">💽</a></td>
-      <td align="center" title="mkdir" style="font-size: 1.5em; padding: 5px;"><a href="src/mkdir.asm" style="text-decoration: none;">📁</a></td>
-    </tr>
-    <tr>
-      <td align="center" title="yes" style="font-size: 1.5em; padding: 5px;"><a href="src/yes.asm" style="text-decoration: none;">🔁</a></td>
-      <td align="center" title="wait" style="font-size: 1.5em; padding: 5px;"><a href="src/wait.asm" style="text-decoration: none;">⏳</a></td>
-      <td align="center" title="echo" style="font-size: 1.5em; padding: 5px;"><a href="src/echo.asm" style="text-decoration: none;">🗣️</a></td>
-      <td align="center" title="timeout" style="font-size: 1.5em; padding: 5px;"><a href="src/timeout.asm" style="text-decoration: none;">⌛</a></td>
-      <td align="center" title="hash" style="font-size: 1.5em; padding: 5px;"><a href="src/hash.asm" style="text-decoration: none;">🔐</a></td>
-      <td align="center" title="logger" style="font-size: 1.5em; padding: 5px;"><a href="src/logger.asm" style="text-decoration: none;">📓</a></td>
-      <td align="center" title="tty" style="font-size: 1.5em; padding: 5px;"><a href="src/tty.asm" style="text-decoration: none;">📺</a></td>
-      <td align="center" title="read" style="font-size: 1.5em; padding: 5px;"><a href="src/read.asm" style="text-decoration: none;">📖</a></td>
-      <td align="center" title="chcon" style="font-size: 1.5em; padding: 5px;"><a href="src/chcon.asm" style="text-decoration: none;">🛡️</a></td>
-      <td align="center" title="env" style="font-size: 1.5em; padding: 5px;"><a href="src/env.asm" style="text-decoration: none;">🌐</a></td>
-      <td align="center" title="sleep" style="font-size: 1.5em; padding: 5px;"><a href="src/sleep.asm" style="text-decoration: none;">💤</a></td>
-      <td align="center" title="unlink" style="font-size: 1.5em; padding: 5px;"><a href="src/unlink.asm" style="text-decoration: none;">🔓</a></td>
-    </tr>
-    <tr>
-      <td align="center" title="write" style="font-size: 1.5em; padding: 5px;"><a href="src/write.asm" style="text-decoration: none;">✉️</a></td>
-      <td align="center" title="tabs" style="font-size: 1.5em; padding: 5px;"><a href="src/tabs.asm" style="text-decoration: none;">📑</a></td>
-      <td align="center" title="pinky" style="font-size: 1.5em; padding: 5px;"><a href="src/pinky.asm" style="text-decoration: none;">👆</a></td>
-      <td align="center" title="rm" style="font-size: 1.5em; padding: 5px;"><a href="src/rm.asm" style="text-decoration: none;">🗑️</a></td>
-      <td align="center" title="command" style="font-size: 1.5em; padding: 5px;"><a href="src/command.asm" style="text-decoration: none;">⚡</a></td>
-      <td align="center" title="gettext" style="font-size: 1.5em; padding: 5px;"><a href="src/gettext.asm" style="text-decoration: none;">💬</a></td>
-      <td align="center" title="arch" style="font-size: 1.5em; padding: 5px;"><a href="src/arch.asm" style="text-decoration: none;">🏗️</a></td>
-      <td align="center" title="pwd" style="font-size: 1.5em; padding: 5px;"><a href="src/pwd.asm" style="text-decoration: none;">🧭</a></td>
-      <td align="center" title="dircolors" style="font-size: 1.5em; padding: 5px;"><a href="src/dircolors.asm" style="text-decoration: none;">🎨</a></td>
-      <td align="center" title="sync" style="font-size: 1.5em; padding: 5px;"><a href="src/sync.asm" style="text-decoration: none;">🔃</a></td>
-      <td align="center" title="false" style="font-size: 1.5em; padding: 5px;"><a href="src/false.asm" style="text-decoration: none;">❌</a></td>
-      <td align="center" title="true" style="font-size: 1.5em; padding: 5px;"><a href="src/true.asm" style="text-decoration: none;">✅</a></td>
-    </tr>
-    <tr>
-      <td align="center" title="true" style="font-size: 1.5em; padding: 5px;"><a href="src/pr.asm" style="text-decoration: none;">📄</a></td>
-      <td align="center" title="true" style="font-size: 1.5em; padding: 5px;"><a href="src/m4.asm" style="text-decoration: none;">🔁</a></td>
-      <td align="center" title="true" style="font-size: 1.5em; padding: 5px;"><a href="src/patch.asm" style="text-decoration: none;">🩹</a></td>
-      <td align="center" title="true" style="font-size: 1.5em; padding: 5px;"><a href="src/mailx.asm" style="text-decoration: none;">📧</a></td>
-      <td align="center" title="true" style="font-size: 1.5em; padding: 5px;"><a href="src/msgfmt.asm" style="text-decoration: none;">📬</a></td>
-      <td align="center" title="true" style="font-size: 1.5em; padding: 5px;"><a href="src/file.asm" style="text-decoration: none;">📎</a></td>
-    </tr>
-  </tbody>
-</table>
+| Emoji | Name | Description | Status | Source |
+| :---: | --- | --- | :---: | --- |
+| 🏷️ | [`alias`](src/alias.asm) | Defines or displays aliases | ✅ Done | [`src/alias.asm`](src/alias.asm) |
+| 🗄️ | [`ar`](src/ar.asm) | Creates and maintains libraries | ✅ Done | [`src/ar.asm`](src/ar.asm) |
+| 🏗️ | [`arch`](src/arch.asm) | Prints machine hardware name | ✅ Done | [`src/arch.asm`](src/arch.asm) |
+| ⏰ | [`at`](src/at.asm) | Executes commands at a later time | ✅ Done | [`src/at.asm`](src/at.asm) |
+| 🧪 | [`b2sum`](src/b2sum.asm) | Computes and checks BLAKE2b message digest | ✅ Done | [`src/b2sum.asm`](src/b2sum.asm) |
+| 3️⃣ | [`base32`](src/base32.asm) | Encodes or decodes Base32, and prints result to standard output | ✅ Done | [`src/base32.asm`](src/base32.asm) |
+| 6️⃣ | [`base64`](src/base64.asm) | Encodes or decodes Base64, and prints result to standard output | ✅ Done | [`src/base64.asm`](src/base64.asm) |
+| 🔤 | [`basename`](src/basename.asm) | Removes the path prefix from a given pathname | ✅ Done | [`src/basename.asm`](src/basename.asm) |
+| 🔡 | [`baseenc`](src/baseenc.asm) | Encodes or decodes various encodings and prints result to standard output | ✅ Done | [`src/baseenc.asm`](src/baseenc.asm) |
+| 📚 | [`batch`](src/batch.asm) | Schedules commands to be executed in a batch queue | ✅ Done | [`src/batch.asm`](src/batch.asm) |
+| 🧮 | [`bc`](src/bc.asm) | Arbitrary-precision arithmetic language | ✅ Done | [`src/bc.asm`](src/bc.asm) |
+| 🐱 | [`cat`](src/cat.asm) | Concatenates and prints files | ✅ Done | [`src/cat.asm`](src/cat.asm) |
+| 🚶 | [`cd`](src/cd.asm) | Changes the working directory | ✅ Done | [`src/cd.asm`](src/cd.asm) |
+| 🛡️ | [`chcon`](src/chcon.asm) | Changes file security context | ✅ Done | [`src/chcon.asm`](src/chcon.asm) |
+| 👥 | [`chgrp`](src/chgrp.asm) | Changes file group ownership | ✅ Done | [`src/chgrp.asm`](src/chgrp.asm) |
+| 🔒 | [`chmod`](src/chmod.asm) | Changes the permissions of a file or directory | ✅ Done | [`src/chmod.asm`](src/chmod.asm) |
+| 🔐 | [`chown`](src/chown.asm) | Changes file ownership | ✅ Done | [`src/chown.asm`](src/chown.asm) |
+| 🌱 | [`chroot`](src/chroot.asm) | Changes the root directory | ✅ Done | [`src/chroot.asm`](src/chroot.asm) |
+| 🧾 | [`cksum`](src/cksum.asm) | Checksums (IEEE Ethernet CRC-32) and count the bytes in a file | ✅ Done | [`src/cksum.asm`](src/cksum.asm) |
+| 🔬 | [`cmp`](src/cmp.asm) | Compares two files; see also diff | ✅ Done | [`src/cmp.asm`](src/cmp.asm) |
+| ☯️ | [`comm`](src/comm.asm) | Compares two sorted files line by line | ✅ Done | [`src/comm.asm`](src/comm.asm) |
+| ⚡ | [`command`](src/command.asm) | Executes a simple command | ✅ Done | [`src/command.asm`](src/command.asm) |
+| 📑 | [`cp`](src/cp.asm) | Copy files/directories | ✅ Done | [`src/cp.asm`](src/cp.asm) |
+| 🗓️ | [`crontab`](src/crontab.asm) | Schedule periodic background work | ✅ Done | [`src/crontab.asm`](src/crontab.asm) |
+| 📂 | [`csplit`](src/csplit.asm) | Splits a file into sections determined by context lines | ✅ Done | [`src/csplit.asm`](src/csplit.asm) |
+| ✂️ | [`cut`](src/cut.asm) | Removes sections from each line of files | ✅ Done | [`src/cut.asm`](src/cut.asm) |
+| 📅 | [`date`](src/date.asm) | Sets or displays the date and time | ✅ Done | [`src/date.asm`](src/date.asm) |
+| 💾 | [`dd`](src/dd.asm) | Copies and converts a file | ✅ Done | [`src/dd.asm`](src/dd.asm) |
+| 💽 | [`df`](src/df.asm) | Shows disk free space on file systems | ✅ Done | [`src/df.asm`](src/df.asm) |
+| 🔍 | [`diff`](src/diff.asm) | Compare two files; see also cmp | ✅ Done | [`src/diff.asm`](src/diff.asm) |
+| 🎨 | [`dircolors`](src/dircolors.asm) | Set up color for ls | ✅ Done | [`src/dircolors.asm`](src/dircolors.asm) |
+| 📁 | [`dirname`](src/dirname.asm) | Strips non-directory suffix from file name | ✅ Done | [`src/dirname.asm`](src/dirname.asm) |
+| 📊 | [`du`](src/du.asm) | Shows disk usage on file systems | ✅ Done | [`src/du.asm`](src/du.asm) |
+| 🗣️ | [`echo`](src/echo.asm) | Displays a specified line of text | ✅ Done | [`src/echo.asm`](src/echo.asm) |
+| 🌐 | [`env`](src/env.asm) | Run a program in a modified environment | ✅ Done | [`src/env.asm`](src/env.asm) |
+| ➡️ | [`expand`](src/expand.asm) | Converts tabs to spaces | ✅ Done | [`src/expand.asm`](src/expand.asm) |
+| 📊 | [`expr`](src/expr.asm) | Evaluates expressions | ✅ Done | [`src/expr.asm`](src/expr.asm) |
+| 🔢 | [`factor`](src/factor.asm) | Factors numbers | ✅ Done | [`src/factor.asm`](src/factor.asm) |
+| ❌ | [`false`](src/false.asm) | Does nothing, but exits unsuccessfully | ✅ Done | [`src/false.asm`](src/false.asm) |
+| 📎 | [`file`](src/file.asm) | Determine file type | ✅ Done | [`src/file.asm`](src/file.asm) |
+| 🔎 | [`find`](src/find.asm) | Find files | ✅ Done | [`src/find.asm`](src/find.asm) |
+| 📐 | [`fmt`](src/fmt.asm) | Simple optimal text formatter | ✅ Done | [`src/fmt.asm`](src/fmt.asm) |
+| 📃 | [`fold`](src/fold.asm) | Wraps each input line to fit in specified width | ✅ Done | [`src/fold.asm`](src/fold.asm) |
+| 😺 | [`gencat`](src/gencat.asm) | Generate a formatted message catalog | ✅ Done | [`src/gencat.asm`](src/gencat.asm) |
+| ⚙️ | [`getconf`](src/getconf.asm) | Get configuration values | ✅ Done | [`src/getconf.asm`](src/getconf.asm) |
+| 🔣 | [`getopts`](src/getopts.asm) | Parse utility options | ✅ Done | [`src/getopts.asm`](src/getopts.asm) |
+| 💬 | [`gettext`](src/gettext.asm) | Retrieve text string from messages object | ✅ Done | [`src/gettext.asm`](src/gettext.asm) |
+| 🔦 | [`grep`](src/grep.asm) | Search text for a pattern | ✅ Done | [`src/grep.asm`](src/grep.asm) |
+| 👪 | [`groups`](src/groups.asm) | Prints the groups of which the user is a member | ✅ Done | [`src/groups.asm`](src/groups.asm) |
+| 🔐 | [`hash`](src/hash.asm) | Hash database access method | ✅ Done | [`src/hash.asm`](src/hash.asm) |
+| ⬆️ | [`head`](src/head.asm) | Output the beginning of files | ✅ Done | [`src/head.asm`](src/head.asm) |
+| 🏷️ | [`hostid`](src/hostid.asm) | Prints the numeric identifier for the current host | ✅ Done | [`src/hostid.asm`](src/hostid.asm) |
+| 🔄 | [`iconv`](src/iconv.asm) | Codeset conversion | ✅ Done | [`src/iconv.asm`](src/iconv.asm) |
+| 🆔 | [`id`](src/id.asm) | Prints real or effective UID and GID | ✅ Done | [`src/id.asm`](src/id.asm) |
+| 📥 | [`install`](src/install.asm) | Copies files and set attributes | ✅ Done | [`src/install.asm`](src/install.asm) |
+| 🔗 | [`join`](src/join.asm) | Merges two sorted text files based on the presence of a common field | ✅ Done | [`src/join.asm`](src/join.asm) |
+| 💀 | [`kill`](src/kill.asm) | Terminate or signal processes | ✅ Done | [`src/kill.asm`](src/kill.asm) |
+| 🔗 | [`link`](src/link.asm) | Creates a link to a file | ✅ Done | [`src/link.asm`](src/link.asm) |
+| 🖇️ | [`ln`](src/ln.asm) | Creates a link to a file | ✅ Done | [`src/ln.asm`](src/ln.asm) |
+| 🌍 | [`locale`](src/locale.asm) | Get locale-specific information | ✅ Done | [`src/locale.asm`](src/locale.asm) |
+| 🌐 | [`localedef`](src/localedef.asm) | Define locale environment | ✅ Done | [`src/localedef.asm`](src/localedef.asm) |
+| 📓 | [`logger`](src/logger.asm) | Log messages | ✅ Done | [`src/logger.asm`](src/logger.asm) |
+| 👤 | [`logname`](src/logname.asm) | Print the user's login name | ✅ Done | [`src/logname.asm`](src/logname.asm) |
+| 🖨️ | [`lp`](src/lp.asm) | Send files to a printer | ✅ Done | [`src/lp.asm`](src/lp.asm) |
+| 📋 | [`ls`](src/ls.asm) | List directory contents with formatting | ✅ Done | [`src/ls.asm`](src/ls.asm) |
+| 🔁 | [`m4`](src/m4.asm) | Macro processor | ✅ Done | [`src/m4.asm`](src/m4.asm) |
+| 📧 | [`mailx`](src/mailx.asm) | Process messages | ✅ Done | [`src/mailx.asm`](src/mailx.asm) |
+| 📚 | [`man`](src/man.asm) | Display system documentation | ✅ Done | [`src/man.asm`](src/man.asm) |
+| 🔑 | [`md5sum`](src/md5sum.asm) | Computes and checks MD5 message digest | ✅ Done | [`src/md5sum.asm`](src/md5sum.asm) |
+| 📨 | [`mesg`](src/mesg.asm) | Permit or deny messages | ✅ Done | [`src/mesg.asm`](src/mesg.asm) |
+| 📁 | [`mkdir`](src/mkdir.asm) | Creates directories | ✅ Done | [`src/mkdir.asm`](src/mkdir.asm) |
+| 📯 | [`mkfifo`](src/mkfifo.asm) | Makes named pipes (FIFOs) | ✅ Done | [`src/mkfifo.asm`](src/mkfifo.asm) |
+| 🧩 | [`mknod`](src/mknod.asm) | Makes block or character special files | ✅ Done | [`src/mknod.asm`](src/mknod.asm) |
+| 📜 | [`mktemp`](src/mktemp.asm) | Creates a temporary file or directory | ✅ Done | [`src/mktemp.asm`](src/mktemp.asm) |
+| 📬 | [`msgfmt`](src/msgfmt.asm) | Create messages objects from messages object files | ✅ Done | [`src/msgfmt.asm`](src/msgfmt.asm) |
+| 🚚 | [`mv`](src/mv.asm) | Moves files or rename files | ✅ Done | [`src/mv.asm`](src/mv.asm) |
+| 👨‍👩‍👧 | [`newgrp`](src/newgrp.asm) | Change to a new group | ✅ Done | [`src/newgrp.asm`](src/newgrp.asm) |
+| 🗯️ | [`ngettext`](src/ngettext.asm) | Retrieve text string from messages object with plural form | ✅ Done | [`src/ngettext.asm`](src/ngettext.asm) |
+| 👌 | [`nice`](src/nice.asm) | Modifies scheduling priority | ✅ Done | [`src/nice.asm`](src/nice.asm) |
+| 🔢 | [`nl`](src/nl.asm) | Numbers lines of files | ✅ Done | [`src/nl.asm`](src/nl.asm) |
+| 🏃 | [`nohup`](src/nohup.asm) | Allows a command to continue running after logging out | ✅ Done | [`src/nohup.asm`](src/nohup.asm) |
+| 🖥️ | [`nproc`](src/nproc.asm) | Queries the number of (active) processors | ✅ Done | [`src/nproc.asm`](src/nproc.asm) |
+| 🔣 | [`numfmt`](src/numfmt.asm) | Reformat numbers | ✅ Done | [`src/numfmt.asm`](src/numfmt.asm) |
+| 👁️ | [`od`](src/od.asm) | Dumps files in octal and other formats | ✅ Done | [`src/od.asm`](src/od.asm) |
+| 📌 | [`paste`](src/paste.asm) | Merge corresponding or subsequent lines of files | ✅ Done | [`src/paste.asm`](src/paste.asm) |
+| 🩹 | [`patch`](src/patch.asm) | Apply changes to files | ✅ Done | [`src/patch.asm`](src/patch.asm) |
+| ✓ | [`pathchk`](src/pathchk.asm) | Checks whether file names are valid or portable | ✅ Done | [`src/pathchk.asm`](src/pathchk.asm) |
+| 📦 | [`pax`](src/pax.asm) | Portable archive interchange | ✅ Done | [`src/pax.asm`](src/pax.asm) |
+| 👆 | [`pinky`](src/pinky.asm) | A lightweight version of finger | ✅ Done | [`src/pinky.asm`](src/pinky.asm) |
+| 📄 | [`pr`](src/pr.asm) | Paginate or columnate files for printing | ✅ Done | [`src/pr.asm`](src/pr.asm) |
+| 🖼️ | [`printenv`](src/printenv.asm) | Prints environment variables | ✅ Done | [`src/printenv.asm`](src/printenv.asm) |
+| 🖊️ | [`printf`](src/printf.asm) | Formats and prints data | ✅ Done | [`src/printf.asm`](src/printf.asm) |
+| 📈 | [`ps`](src/ps.asm) | Report process status | ✅ Done | [`src/ps.asm`](src/ps.asm) |
+| 📇 | [`ptx`](src/ptx.asm) | Produces a permuted index of file contents | ✅ Done | [`src/ptx.asm`](src/ptx.asm) |
+| 🧭 | [`pwd`](src/pwd.asm) | Prints the current working directory | ✅ Done | [`src/pwd.asm`](src/pwd.asm) |
+| 📖 | [`read`](src/read.asm) | Read a line from standard input | ✅ Done | [`src/read.asm`](src/read.asm) |
+| 👉 | [`readlink`](src/readlink.asm) | Print destination of a symbolic link | ✅ Done | [`src/readlink.asm`](src/readlink.asm) |
+| 🛣️ | [`realpath`](src/realpath.asm) | Returns the resolved absolute or relative path for a file | ✅ Done | [`src/realpath.asm`](src/realpath.asm) |
+| 👍 | [`renice`](src/renice.asm) | Set nice values of running processes | ✅ Done | [`src/renice.asm`](src/renice.asm) |
+| 🗑️ | [`rm`](src/rm.asm) | Removes files/directories | ✅ Done | [`src/rm.asm`](src/rm.asm) |
+| 🗂️ | [`rmdir`](src/rmdir.asm) | Removes empty directories | ✅ Done | [`src/rmdir.asm`](src/rmdir.asm) |
+| 🔓 | [`runcon`](src/runcon.asm) | Run command with specified security context | ✅ Done | [`src/runcon.asm`](src/runcon.asm) |
+| 🔄 | [`seq`](src/seq.asm) | Prints a sequence of numbers | ✅ Done | [`src/seq.asm`](src/seq.asm) |
+| 🔏 | [`sha1sum`](src/sha1sum.asm) | Computes and checks SHA-1/SHA-2 message digests | ✅ Done | [`src/sha1sum.asm`](src/sha1sum.asm) |
+| 🔐 | [`sha224sum`](src/sha224sum.asm) | Computes and checks SHA-1/SHA-2 message digests | ✅ Done | [`src/sha224sum.asm`](src/sha224sum.asm) |
+| 🔒 | [`sha256sum`](src/sha256sum.asm) | Computes and checks SHA-1/SHA-2 message digests | ✅ Done | [`src/sha256sum.asm`](src/sha256sum.asm) |
+| 🔓 | [`sha384sum`](src/sha384sum.asm) | Computes and checks SHA-1/SHA-2 message digests | ✅ Done | [`src/sha384sum.asm`](src/sha384sum.asm) |
+| 🔑 | [`sha512sum`](src/sha512sum.asm) | Computes and checks SHA-1/SHA-2 message digests | ✅ Done | [`src/sha512sum.asm`](src/sha512sum.asm) |
+| 🔪 | [`shred`](src/shred.asm) | Overwrites a file to hide its contents, and optionally deletes it | ✅ Done | [`src/shred.asm`](src/shred.asm) |
+| 🎲 | [`shuf`](src/shuf.asm) | generates random permutations | ✅ Done | [`src/shuf.asm`](src/shuf.asm) |
+| 💤 | [`sleep`](src/sleep.asm) | Delays for a specified amount of time | ✅ Done | [`src/sleep.asm`](src/sleep.asm) |
+| 🔠 | [`sort`](src/sort.asm) | Sorts lines of text files | ✅ Done | [`src/sort.asm`](src/sort.asm) |
+| ✂️ | [`split`](src/split.asm) | Splits a file into pieces | ✅ Done | [`src/split.asm`](src/split.asm) |
+| 📊 | [`stat`](src/stat.asm) | Returns data about an inode | ✅ Done | [`src/stat.asm`](src/stat.asm) |
+| 📤 | [`stdbuf`](src/stdbuf.asm) | Controls buffering for commands that use stdio | ✅ Done | [`src/stdbuf.asm`](src/stdbuf.asm) |
+| 🔤 | [`strings`](src/strings.asm) | Find printable strings in files | ✅ Done | [`src/strings.asm`](src/strings.asm) |
+| ⌨️ | [`stty`](src/stty.asm) | Changes and prints terminal line settings | ✅ Done | [`src/stty.asm`](src/stty.asm) |
+| ➕ | [`sum`](src/sum.asm) | Checksums and counts the blocks in a file | ✅ Done | [`src/sum.asm`](src/sum.asm) |
+| 🔃 | [`sync`](src/sync.asm) | Flushes file system buffers | ✅ Done | [`src/sync.asm`](src/sync.asm) |
+| 📑 | [`tabs`](src/tabs.asm) | Set terminal tabs | ✅ Done | [`src/tabs.asm`](src/tabs.asm) |
+| 🙃 | [`tac`](src/tac.asm) | Concatenates and prints files in reverse order line by line | ✅ Done | [`src/tac.asm`](src/tac.asm) |
+| ⬇️ | [`tail`](src/tail.asm) | Output the end of files | ✅ Done | [`src/tail.asm`](src/tail.asm) |
+| 🔱 | [`tee`](src/tee.asm) | Sends output to multiple files | ✅ Done | [`src/tee.asm`](src/tee.asm) |
+| 🧪 | [`test`](src/test.asm) | Evaluates an expression | ✅ Done | [`src/test.asm`](src/test.asm) |
+| ⏱️ | [`time`](src/time.asm) | Display elapsed, system and kernel time | ✅ Done | [`src/time.asm`](src/time.asm) |
+| ⌛ | [`timeout`](src/timeout.asm) | Runs a command with a time limit | ✅ Done | [`src/timeout.asm`](src/timeout.asm) |
+| 👆 | [`touch`](src/touch.asm) | Changes file timestamps; creates file | ✅ Done | [`src/touch.asm`](src/touch.asm) |
+| 🎮 | [`tput`](src/tput.asm) | Change terminal characteristics | ✅ Done | [`src/tput.asm`](src/tput.asm) |
+| 🔡 | [`tr`](src/tr.asm) | Translates or deletes characters | ✅ Done | [`src/tr.asm`](src/tr.asm) |
+| ✅ | [`true`](src/true.asm) | Does nothing, but exits successfully | ✅ Done | [`src/true.asm`](src/true.asm) |
+| 📏 | [`truncate`](src/truncate.asm) | Shrink the size of a file to the specified size | ✅ Done | [`src/truncate.asm`](src/truncate.asm) |
+| 🧶 | [`tsort`](src/tsort.asm) | Performs a topological sort | ✅ Done | [`src/tsort.asm`](src/tsort.asm) |
+| 📺 | [`tty`](src/tty.asm) | Prints terminal name | ✅ Done | [`src/tty.asm`](src/tty.asm) |
+| 🎭 | [`umask`](src/umask.asm) | Get or set the file mode creation mask | ✅ Done | [`src/umask.asm`](src/umask.asm) |
+| 🚫 | [`unalias`](src/unalias.asm) | Remove alias definitions | ✅ Done | [`src/unalias.asm`](src/unalias.asm) |
+| 💻 | [`uname`](src/uname.asm) | Prints system information | ✅ Done | [`src/uname.asm`](src/uname.asm) |
+| ⬅️ | [`unexpand`](src/unexpand.asm) | Converts spaces to tabs | ✅ Done | [`src/unexpand.asm`](src/unexpand.asm) |
+| 🎯 | [`uniq`](src/uniq.asm) | Removes duplicate lines from a sorted file | ✅ Done | [`src/uniq.asm`](src/uniq.asm) |
+| 🔓 | [`unlink`](src/unlink.asm) | Removes the specified file using the unlink function | ✅ Done | [`src/unlink.asm`](src/unlink.asm) |
+| ⏰ | [`uptime`](src/uptime.asm) | Tells how long the system has been running | ✅ Done | [`src/uptime.asm`](src/uptime.asm) |
+| 👨‍👩‍👧‍👦 | [`users`](src/users.asm) | Prints the user names of users currently logged in | ✅ Done | [`src/users.asm`](src/users.asm) |
+| 📩 | [`uudecode`](src/uudecode.asm) | Decode a binary file | ✅ Done | [`src/uudecode.asm`](src/uudecode.asm) |
+| 📫 | [`uuencode`](src/uuencode.asm) | Encode a binary file | ✅ Done | [`src/uuencode.asm`](src/uuencode.asm) |
+| ⏳ | [`wait`](src/wait.asm) | Await process completion | ✅ Done | [`src/wait.asm`](src/wait.asm) |
+| 🔡 | [`wc`](src/wc.asm) | Prints the number of bytes, words, and lines in files | ✅ Done | [`src/wc.asm`](src/wc.asm) |
+| 👨‍👨‍👧‍👧 | [`who`](src/who.asm) | Prints a list of all users currently logged in | ✅ Done | [`src/who.asm`](src/who.asm) |
+| 🙋 | [`whoami`](src/whoami.asm) | Prints the effective userid | ✅ Done | [`src/whoami.asm`](src/whoami.asm) |
+| ✉️ | [`write`](src/write.asm) | Write to another user's terminal | ✅ Done | [`src/write.asm`](src/write.asm) |
+| 🔨 | [`xargs`](src/xargs.asm) | Construct argument lists and invoke utility | ✅ Done | [`src/xargs.asm`](src/xargs.asm) |
+| 🔁 | [`yes`](src/yes.asm) | Prints a string repeatedly | ✅ Done | [`src/yes.asm`](src/yes.asm) |
 
 ## 🛠 Build Instructions
 simply run

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -8,15 +8,18 @@ from pathlib import Path
 def catalog_entry_line(entry: dict[str, object], src_dir: Path) -> str:
     name = str(entry["name"])
     asm_path = src_dir / f"{name}.asm"
-    status = "✅" if entry["isDone"] else "⛔️"
+    emoji = str(entry["glyph"])
+    status = "✅ Done" if entry["isDone"] else "⛔️ Pending"
     description = str(entry["description"])
 
     if asm_path.exists():
         name_rendered = f"[`{name}`](src/{name}.asm)"
+        source_rendered = f"[`src/{name}.asm`](src/{name}.asm)"
     else:
         name_rendered = f"`{name}`"
+        source_rendered = "—"
 
-    return f"- {name_rendered} {status} {description}"
+    return f"| {emoji} | {name_rendered} | {description} | {status} | {source_rendered} |"
 
 
 def main() -> None:
@@ -49,15 +52,21 @@ def main() -> None:
         if line.strip() == "## Catalog":
             start = i + 1
             continue
-        if start is not None and line.startswith("## Benchmark"):
+        if start is not None and line.startswith("## "):
             end = i
             break
     if start is None or end is None:
         raise RuntimeError("Failed to locate catalog section in README")
 
-    catalog_lines = [catalog_entry_line(entry, src_dir) for entry in data]
+    catalog_lines = [
+        "",
+        "| Emoji | Name | Description | Status | Source |",
+        "| :---: | --- | --- | :---: | --- |",
+        *[catalog_entry_line(entry, src_dir) for entry in data],
+        "",
+    ]
 
-    lines[start:end] = catalog_lines + [""]
+    lines[start:end] = catalog_lines
     readme_path.write_text("\n".join(lines) + "\n")
 
 


### PR DESCRIPTION
### Motivation
- Improve README catalog readability and machine-parsability by replacing a large HTML emoji grid with a structured Markdown table containing all available metadata. 
- Make the README generation script produce and preserve the new table format so `Baloo.json` remains the single source of truth. 

### Description
- Replace the HTML emoji grid in `README.md` with a Markdown table that has columns `Emoji`, `Name`, `Description`, `Status`, and `Source`. 
- Update `scripts/update_readme.py` to emit table rows including each entry's `glyph`, linked `Name` (`[`name`](src/name.asm)`), `description`, human-friendly `Status` (`✅ Done` / `⛔️ Pending`), and a `Source` link to the `src/*.asm` file. 
- Make catalog replacement in `scripts/update_readme.py` stop at the next top-level README heading (`line.startswith("## ")`) so the catalog section is located robustly. 

### Testing
- Ran the README idempotence check with `python3 scripts/update_readme.py` and `cmp` to confirm running the generator does not further change the README; the check succeeded. 
- Ran a validation script that loads `Baloo.json` and verifies there are 150 catalog rows and that each row contains the linked name, glyph, description, and source link; validation succeeded for all entries. 
- Ran the updated `scripts/update_readme.py` to regenerate the catalog and confirmed the generated table is well-formed and includes all binaries; regeneration is idempotent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a342dc4644083289dbe207ff52e683c)